### PR TITLE
Fix CI: correct Documenter.jl section ID syntax

### DIFF
--- a/docs/src/manual/polynomial_optimization.md
+++ b/docs/src/manual/polynomial_optimization.md
@@ -1,4 +1,4 @@
-# [Polynomial Optimization] (@id polynomial-optimization)
+# [Polynomial Optimization](@id polynomial-optimization)
 
 Polynomial optimization is a [mathematical optimization
 problem](https://en.wikipedia.org/wiki/Mathematical_optimization) where the

--- a/docs/src/manual/sdp_relaxation.md
+++ b/docs/src/manual/sdp_relaxation.md
@@ -1,4 +1,4 @@
-# [Semidefinite Programming] (@id semidefinite-programming)
+# [Semidefinite Programming](@id semidefinite-programming)
 
 Semidefinite Programming (SDP) is a powerful optimization technique that can be
 used to solve a wide variety of problems in science and engineering, including


### PR DESCRIPTION
## Summary
- Fixed broken cross-references in documentation causing CI failures
- Removed space between `]` and `(@id` in section headers per Documenter.jl syntax

## Root Cause
The documentation build was failing due to incorrect spacing in section ID declarations:
- `docs/src/manual/polynomial_optimization.md:1`
- `docs/src/manual/sdp_relaxation.md:1`

## Changes
**Before:**
```markdown
# [Polynomial Optimization] (@id polynomial-optimization)
# [Semidefinite Programming] (@id semidefinite-programming)
```

**After:**
```markdown
# [Polynomial Optimization](@id polynomial-optimization)
# [Semidefinite Programming](@id semidefinite-programming)
```

## Test Plan
- [x] Fixed syntax in both documentation files
- [x] Verify CI documentation build passes
- [x] Verify cross-references resolve correctly

## Context
This issue was introduced in commit 8ec94f2 and caught by CI on the recent commit ec3d1e8. Tests pass; only documentation build was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)