### PR TITLE
test: add JSON expectations fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ benchmark/result.json
 *.json
 *.json.tmp
 
+# JSON fixtures (tracked)
+!test/data/**/*.json
+!docs/src/examples/literate/data/**/*.json
+
 # Garbage Generate by MacOS and VSCode
 */.DS_Store
 .DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ CliqueTrees = "1"
 Documenter = "1.13.0"
 ExplicitImports = "1.11.3"
 Graphs = "1.5"
+JSON3 = "1"
 JuMP = "1.26.0"
 LinearAlgebra = "1.12"
 SparseArrays = "1.12"
@@ -32,7 +33,8 @@ COSMO = "1e616198-aa4e-51ec-90a2-23f7fbd31d8d"
 Clarabel = "61c947e1-3e6d-4ee4-985a-eec8c727bd6e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Clarabel", "COSMO", "Aqua", "Documenter", "ExplicitImports"]
+test = ["Test", "Clarabel", "COSMO", "Aqua", "Documenter", "ExplicitImports", "JSON3"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,7 @@ Clarabel = "61c947e1-3e6d-4ee4-985a-eec8c727bd6e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 MosekTools = "1ec41992-ff65-5c91-ac43-2df89e9693a4"
@@ -13,4 +14,5 @@ Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
 
 [compat]
 Documenter = "1.13.0"
+JSON3 = "1"
 MosekTools = "0.15.9"

--- a/docs/examples_stamp.toml
+++ b/docs/examples_stamp.toml
@@ -1,4 +1,4 @@
 format_version = 1
 generator_hash = "01c5a3cf088a5f8719983b358413b9e503a6a4d242019ff791cbd22a2152b27b"
-literate_hash = "9db41f04faf3b2d2ea1753ecd9ab9a58bbceacf68d642f70cf85f9fe0d00955e"
+literate_hash = "35bedbc6b175b6e62fe0aca4d6b7355b337713e9de9243ba4cfb4875f4ca6aef"
 src_hash = "da08193639cc4afabaed9392b8a3e3f260fe7e8903ddffd8689943942e1907e1"

--- a/docs/src/examples/generated/trace_poly.md
+++ b/docs/src/examples/generated/trace_poly.md
@@ -27,6 +27,9 @@ solver output.
 
 ````julia
 using NCTSSoS, MosekTools
+using JSON3
+
+const TRACE_POLY_REFS = JSON3.read(read(joinpath(@__DIR__, "data", "trace_poly_refs.json"), String))
 
 const MOI = NCTSSoS.MOI
 const SILENT_MOSEK = MOI.OptimizerWithAttributes(Mosek.Optimizer, MOI.Silent() => true);
@@ -78,7 +81,7 @@ solver_config = SolverConfig(; optimizer=SILENT_MOSEK, order=2);
 result = cs_nctssos(spop, solver_config);
 
 @show result.objective
-@assert isapprox(result.objective, -0.046717378455438933, atol=1e-6)
+@assert isapprox(result.objective, TRACE_POLY_REFS["toy_projector_order2_objective"], atol=1e-6)
 ````
 
 ````
@@ -93,7 +96,7 @@ solver_config = SolverConfig(; optimizer=SILENT_MOSEK, order=3);
 result = cs_nctssos(spop, solver_config);
 
 @show result.objective
-@assert isapprox(result.objective, -0.03124998978001017, atol=1e-6)
+@assert isapprox(result.objective, TRACE_POLY_REFS["toy_projector_order3_objective"], atol=1e-6)
 ````
 
 ````
@@ -278,4 +281,3 @@ For linear (non-tracial) Bell inequalities, see the
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
-

--- a/docs/src/examples/literate/data/trace_poly_refs.json
+++ b/docs/src/examples/literate/data/trace_poly_refs.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "toy_projector_order2_objective": -0.046717378455438933,
+  "toy_projector_order3_objective": -0.03124998978001017
+}
+

--- a/docs/src/examples/literate/trace_poly.jl
+++ b/docs/src/examples/literate/trace_poly.jl
@@ -22,6 +22,9 @@
 # solver output.
 
 using NCTSSoS, MosekTools
+using JSON3
+
+const TRACE_POLY_REFS = JSON3.read(read(joinpath(@__DIR__, "data", "trace_poly_refs.json"), String))
 
 const MOI = NCTSSoS.MOI
 const SILENT_MOSEK = MOI.OptimizerWithAttributes(Mosek.Optimizer, MOI.Silent() => true);
@@ -70,7 +73,7 @@ solver_config = SolverConfig(; optimizer=SILENT_MOSEK, order=2);
 result = cs_nctssos(spop, solver_config);
 
 @show result.objective
-@assert isapprox(result.objective, -0.046717378455438933, atol=1e-6)
+@assert isapprox(result.objective, TRACE_POLY_REFS["toy_projector_order2_objective"], atol=1e-6)
 
 # #### Step 4 — Tighten the bound at order 3
 
@@ -78,7 +81,7 @@ solver_config = SolverConfig(; optimizer=SILENT_MOSEK, order=3);
 result = cs_nctssos(spop, solver_config);
 
 @show result.objective
-@assert isapprox(result.objective, -0.03124998978001017, atol=1e-6)
+@assert isapprox(result.objective, TRACE_POLY_REFS["toy_projector_order3_objective"], atol=1e-6)
 
 # The literature values are $-0.0467$ (order 2) and $-0.0312$ (order 3); our
 # results match within $10^{-6}$ [klep2022Optimization](@cite).

--- a/test/Expectations.jl
+++ b/test/Expectations.jl
@@ -1,0 +1,51 @@
+module TestExpectations
+
+using JSON3
+using NCTSSoS
+
+export expectations_path,
+       expectations_load,
+       expectations_case,
+       expectations_oracle
+
+const TEST_DATA_DIR = joinpath(pkgdir(NCTSSoS), "test", "data")
+
+expectations_path(parts::AbstractString...) = joinpath(TEST_DATA_DIR, parts...)
+
+function expectations_load(relpath::AbstractString)
+    path = expectations_path(relpath)
+    return JSON3.read(read(path, String))
+end
+
+function expectations_case(data, id::AbstractString)
+    haskey(data, "cases") || error("Missing key `cases` in expectations JSON.")
+    for case in data["cases"]
+        String(case["id"]) == id && return case
+    end
+    error("Case id not found in expectations JSON: $(repr(id))")
+end
+
+function expectations_oracle(relpath::AbstractString, id::AbstractString)
+    data = expectations_load(relpath)
+    case = expectations_case(data, id)
+    haskey(case, "expected") || error("Missing key `expected` for case $(repr(id)).")
+    expected = case["expected"]
+
+    haskey(expected, "objective") || error("Missing key `expected.objective` for case $(repr(id)).")
+    oracle = (opt=Float64(expected["objective"]),)
+
+    if haskey(expected, "sides")
+        oracle = merge(oracle, (sides=[Int(x) for x in expected["sides"]],))
+    end
+
+    if haskey(expected, "nuniq")
+        oracle = merge(oracle, (nuniq=Int(expected["nuniq"]),))
+    elseif haskey(expected, "n_unique_moment_matrix_elements")
+        oracle = merge(oracle, (nuniq=Int(expected["n_unique_moment_matrix_elements"]),))
+    end
+
+    return oracle
+end
+
+end
+

--- a/test/correlated_sparsity/runtests.jl
+++ b/test/correlated_sparsity/runtests.jl
@@ -24,8 +24,8 @@ if !@isdefined(SOLVER)
 end
 
 const CORRELATED_PIPELINE_ORACLES = (
-    CS_d3 = (opt=0.9975308091952613, sides=[15, 15], nuniq=149),
-    TS_d3 = (opt=0.9975305666745705, nuniq=123),  # sides vary
+    CS_d3 = expectations_oracle("expectations/correlated_pipeline.json", "CS_d3"),
+    TS_d3 = expectations_oracle("expectations/correlated_pipeline.json", "TS_d3"),  # sides vary
 )
 
 if !isdefined(@__MODULE__, :flatten_sizes)

--- a/test/data/README.md
+++ b/test/data/README.md
@@ -1,0 +1,29 @@
+# Test Data
+
+This directory stores reviewed expectation values (fixtures) used by solver-dependent tests.
+
+## Layout
+
+- `expectations/*.json`: numeric expectations keyed by stable `id` strings.
+
+## JSON schema (v1)
+
+Top-level object:
+
+- `schema_version` (Int): currently `1`
+- `cases` (Array): list of cases
+
+Each case:
+
+- `id` (String): stable identifier referenced by tests
+- `expected` (Object):
+  - `objective` (Number): expected objective value
+  - `sides` (Array[Int], optional): expected flattened moment-matrix block sizes
+  - `nuniq` (Int, optional): expected `n_unique_moment_matrix_elements`
+- `notes` (String, optional): provenance / verification notes
+
+## Update workflow
+
+- When a verified expectation changes, update the corresponding JSON file and keep `id`s stable.
+- Prefer one JSON file per test suite (e.g. CHSH, NC examples, correlated sparsity).
+

--- a/test/data/expectations/chsh_simple.json
+++ b/test/data/expectations/chsh_simple.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "Dense_d1",
+      "expected": {
+        "objective": -2.8284271321623193,
+        "sides": [5],
+        "nuniq": 11
+      }
+    },
+    {
+      "id": "CS_d1",
+      "expected": {
+        "objective": -2.8284271247170496,
+        "sides": [4, 4],
+        "nuniq": 10
+      }
+    },
+    {
+      "id": "TS_d1",
+      "expected": {
+        "objective": -2.8284271247321175,
+        "sides": [3, 3, 1],
+        "nuniq": 6
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/chsh_state.json
+++ b/test/data/expectations/chsh_state.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "Dense",
+      "expected": {
+        "objective": -2.828427124746234,
+        "sides": [9],
+        "nuniq": 21
+      }
+    },
+    {
+      "id": "TS",
+      "expected": {
+        "objective": -2.8284271247321175,
+        "nuniq": 10
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/chsh_trace.json
+++ b/test/data/expectations/chsh_trace.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "Dense",
+      "expected": {
+        "objective": -2.828427124746234,
+        "sides": [9],
+        "nuniq": 21
+      }
+    },
+    {
+      "id": "TS",
+      "expected": {
+        "objective": -2.8284271247321175,
+        "nuniq": 10
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/correlated_pipeline.json
+++ b/test/data/expectations/correlated_pipeline.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "CS_d3",
+      "expected": {
+        "objective": 0.9975308091952613,
+        "sides": [15, 15],
+        "nuniq": 149
+      }
+    },
+    {
+      "id": "TS_d3",
+      "expected": {
+        "objective": 0.9975305666745705,
+        "nuniq": 123
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/nc_example1.json
+++ b/test/data/expectations/nc_example1.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "Dense_d2",
+      "expected": {
+        "objective": -3.936210849199504e-10,
+        "sides": [13],
+        "nuniq": 73
+      }
+    },
+    {
+      "id": "TS_d2",
+      "expected": {
+        "objective": -0.0035512846020968616,
+        "sides": [1, 1, 2, 2, 2, 2, 3, 3, 3, 4],
+        "nuniq": 21
+      }
+    },
+    {
+      "id": "SOS_d2",
+      "expected": {
+        "objective": 0.0
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/nc_example2.json
+++ b/test/data/expectations/nc_example2.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "opt",
+      "expected": {
+        "objective": -1.0
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/relaxations_interface.json
+++ b/test/data/expectations/relaxations_interface.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "dualization_naive_pauli_d1",
+      "expected": {
+        "objective": -0.8660254037844387
+      }
+    },
+    {
+      "id": "dualization_trivial_true_min",
+      "expected": {
+        "objective": 3.0
+      }
+    },
+    {
+      "id": "check_solver_status_min",
+      "expected": {
+        "objective": 1.0
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/relaxations_sparsity.json
+++ b/test/data/expectations/relaxations_sparsity.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "unipotent_n2_order1_dense",
+      "expected": {
+        "objective": -1.0,
+        "sides": [3],
+        "nuniq": 4
+      }
+    },
+    {
+      "id": "unipotent_n1_order1_dense",
+      "expected": {
+        "objective": -1.0,
+        "sides": [2],
+        "nuniq": 2
+      }
+    }
+  ]
+}
+

--- a/test/data/expectations/trace_optimization_paths.json
+++ b/test/data/expectations/trace_optimization_paths.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "id": "dense_auto_order",
+      "expected": {
+        "objective": -2.8284271247461903,
+        "sides": [9],
+        "nuniq": 21
+      }
+    },
+    {
+      "id": "mmd_order1",
+      "expected": {
+        "objective": -2.8284271247461903,
+        "nuniq": 10
+      }
+    }
+  ]
+}
+

--- a/test/expectations_loader.jl
+++ b/test/expectations_loader.jl
@@ -1,0 +1,16 @@
+using Test
+
+@testset "Expectations JSON Fixtures" begin
+    data = TestExpectations.expectations_load("expectations/chsh_simple.json")
+    @test data["schema_version"] == 1
+
+    case = TestExpectations.expectations_case(data, "Dense_d1")
+    @test haskey(case, "expected")
+    @test haskey(case["expected"], "objective")
+
+    oracle = expectations_oracle("expectations/chsh_simple.json", "Dense_d1")
+    @test oracle.opt isa Float64
+    @test oracle.nuniq isa Int
+    @test oracle.sides isa Vector{Int}
+end
+

--- a/test/problems/bell_inequalities/chsh_simple.jl
+++ b/test/problems/bell_inequalities/chsh_simple.jl
@@ -6,12 +6,7 @@
 
 using Test, NCTSSoS, JuMP
 
-# Oracle values from NCTSSOS
-const CHSH_SIMPLE_ORACLES = (
-    Dense_d1 = (opt=-2.8284271321623193, sides=[5], nuniq=11),
-    CS_d1    = (opt=-2.8284271247170496, sides=[4, 4], nuniq=10),
-    TS_d1    = (opt=-2.8284271247321175, sides=[3, 3, 1], nuniq=6),
-)
+# Expectations in test/data/expectations/chsh_simple.json
 
 function create_chsh_problem()
     reg, (x, y) = create_unipotent_variables([("x", 1:2), ("y", 1:2)])
@@ -23,6 +18,7 @@ end
 @testset "CHSH Simple (order=1)" begin
 
     @testset "Dense" begin
+        oracle = expectations_oracle("expectations/chsh_simple.json", "Dense_d1")
         pop, _ = create_chsh_problem()
         config = SolverConfig(
             optimizer=SOLVER,
@@ -32,12 +28,13 @@ end
         )
         result = cs_nctssos(pop, config)
 
-        @test result.objective ≈ CHSH_SIMPLE_ORACLES.Dense_d1.opt atol = 1e-6
-        @test flatten_sizes(result.moment_matrix_sizes) == CHSH_SIMPLE_ORACLES.Dense_d1.sides
-        @test result.n_unique_moment_matrix_elements == CHSH_SIMPLE_ORACLES.Dense_d1.nuniq
+        @test result.objective ≈ oracle.opt atol = 1e-6
+        @test flatten_sizes(result.moment_matrix_sizes) == oracle.sides
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 
     @testset "Correlative Sparsity (MF)" begin
+        oracle = expectations_oracle("expectations/chsh_simple.json", "CS_d1")
         pop, _ = create_chsh_problem()
         config = SolverConfig(
             optimizer=SOLVER,
@@ -47,12 +44,13 @@ end
         )
         result = cs_nctssos(pop, config)
 
-        @test result.objective ≈ CHSH_SIMPLE_ORACLES.CS_d1.opt atol = 1e-6
-        @test flatten_sizes(result.moment_matrix_sizes) == CHSH_SIMPLE_ORACLES.CS_d1.sides
-        @test result.n_unique_moment_matrix_elements == CHSH_SIMPLE_ORACLES.CS_d1.nuniq
+        @test result.objective ≈ oracle.opt atol = 1e-6
+        @test flatten_sizes(result.moment_matrix_sizes) == oracle.sides
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 
     @testset "Term Sparsity (MMD)" begin
+        oracle = expectations_oracle("expectations/chsh_simple.json", "TS_d1")
         pop, _ = create_chsh_problem()
         config = SolverConfig(
             optimizer=SOLVER,
@@ -62,9 +60,9 @@ end
         )
         result = cs_nctssos(pop, config)
 
-        @test result.objective ≈ CHSH_SIMPLE_ORACLES.TS_d1.opt atol = 1e-6
-        @test flatten_sizes(result.moment_matrix_sizes) == CHSH_SIMPLE_ORACLES.TS_d1.sides
-        @test result.n_unique_moment_matrix_elements == CHSH_SIMPLE_ORACLES.TS_d1.nuniq
+        @test result.objective ≈ oracle.opt atol = 1e-6
+        @test flatten_sizes(result.moment_matrix_sizes) == oracle.sides
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 
 end

--- a/test/problems/nc_polynomial/nc_example1.jl
+++ b/test/problems/nc_polynomial/nc_example1.jl
@@ -5,11 +5,7 @@
 
 using Test, NCTSSoS, JuMP
 
-# Oracle values from NCTSSOS
-const NC_EXAMPLE1_ORACLES = (
-    Dense_d2 = (opt=-3.936210849199504e-10, sides=[13], nuniq=73),
-    TS_d2    = (opt=-0.0035512846020968616, sides=[1, 1, 2, 2, 2, 2, 3, 3, 3, 4], nuniq=21),
-)
+# Expectations in test/data/expectations/nc_example1.json
 
 @testset "NC Example 1 (unconstrained)" begin
     n = 3
@@ -24,7 +20,7 @@ const NC_EXAMPLE1_ORACLES = (
     pop = polyopt(f, reg)
 
     @testset "Dense (order=2)" begin
-        oracle = NC_EXAMPLE1_ORACLES.Dense_d2
+        oracle = expectations_oracle("expectations/nc_example1.json", "Dense_d2")
         config = SolverConfig(
             optimizer=SOLVER,
             order=2,
@@ -38,13 +34,14 @@ const NC_EXAMPLE1_ORACLES = (
     end
 
     @testset "Dense (SOS)" begin
+        oracle = expectations_oracle("expectations/nc_example1.json", "SOS_d2")
         config = SolverConfig(optimizer=SOLVER, order=2)
         result = cs_nctssos(pop, config; dualize=true)
-        @test result.objective ≈ 0.0 atol = 1e-6
+        @test result.objective ≈ oracle.opt atol = 1e-6
     end
 
     @testset "Term Sparsity MMD (order=2)" begin
-        oracle = NC_EXAMPLE1_ORACLES.TS_d2
+        oracle = expectations_oracle("expectations/nc_example1.json", "TS_d2")
         config = SolverConfig(
             optimizer=SOLVER,
             order=2,

--- a/test/problems/nc_polynomial/nc_example2.jl
+++ b/test/problems/nc_polynomial/nc_example2.jl
@@ -7,6 +7,7 @@
 using Test, NCTSSoS, JuMP
 
 @testset "NC Example 2 (constrained)" begin
+    opt_oracle = expectations_oracle("expectations/nc_example2.json", "opt")
     n = 2
     reg, (x,) = create_noncommutative_variables([("x", 1:n)])
 
@@ -19,13 +20,13 @@ using Test, NCTSSoS, JuMP
     @testset "Dense (Moment)" begin
         config = SolverConfig(optimizer=SOLVER, order=2)
         result = cs_nctssos(pop, config; dualize=false)
-        @test result.objective ≈ -1.0 atol = 1e-6
+        @test result.objective ≈ opt_oracle.opt atol = 1e-6
     end
 
     @testset "Dense (SOS)" begin
         config = SolverConfig(optimizer=SOLVER, order=2)
         result = cs_nctssos(pop, config; dualize=true)
-        @test result.objective ≈ -1.0 atol = 1e-6
+        @test result.objective ≈ opt_oracle.opt atol = 1e-6
     end
 
     @testset "Term Sparsity (Moment)" begin
@@ -36,7 +37,7 @@ using Test, NCTSSoS, JuMP
             ts_algo=MMD()
         )
         result = cs_nctssos(pop, config; dualize=false)
-        @test result.objective ≈ -1.0 atol = 1e-6
+        @test result.objective ≈ opt_oracle.opt atol = 1e-6
     end
 
     @testset "Term Sparsity (SOS)" begin
@@ -46,7 +47,7 @@ using Test, NCTSSoS, JuMP
             ts_algo=MMD()
         )
         result = cs_nctssos(pop, config; dualize=true)
-        @test result.objective ≈ -1.0 atol = 1e-6
+        @test result.objective ≈ opt_oracle.opt atol = 1e-6
     end
 
     @testset "cs_nctssos_higher" begin

--- a/test/relaxations/interface.jl
+++ b/test/relaxations/interface.jl
@@ -103,9 +103,10 @@ end
         # Both dualize=true and dualize=false now work for complex (Pauli) algebra
         res_mom = cs_nctssos(pop, solver_config; dualize=false)
         res_sos = cs_nctssos(pop, solver_config; dualize=true)
+        oracle = expectations_oracle("expectations/relaxations_interface.json", "dualization_naive_pauli_d1")
         # Both should give the same result
         @test res_mom.objective ≈ res_sos.objective atol = 1e-6
-        @test res_sos.objective ≈ -0.8660254037844387 atol = 1e-6
+        @test res_sos.objective ≈ oracle.opt atol = 1e-6
     end
 
     @testset "Trivial Example" begin
@@ -125,7 +126,8 @@ end
 
         result = cs_nctssos(pop, solver_config; dualize=true)
 
-        @test isapprox(result.objective, true_min, atol=1e-6)
+        oracle = expectations_oracle("expectations/relaxations_interface.json", "dualization_trivial_true_min")
+        @test isapprox(result.objective, oracle.opt, atol=1e-6)
     end
 
     # This test requires high precision solver - COSMO gives Inf for one method
@@ -293,7 +295,8 @@ end
 
         # This should solve successfully and not throw
         result = cs_nctssos(pop, solver_config)
-        @test result.objective ≈ 1.0 atol=1e-4
+        oracle = expectations_oracle("expectations/relaxations_interface.json", "check_solver_status_min")
+        @test result.objective ≈ oracle.opt atol=1e-4
     end
 
     @testset "Status constants are defined" begin

--- a/test/relaxations/sparsity.jl
+++ b/test/relaxations/sparsity.jl
@@ -37,6 +37,7 @@ end
 
 @testset "PolyOptResult Fields" begin
     @testset "moment_matrix_sizes and n_unique_moment_matrix_elements" begin
+        oracle = expectations_oracle("expectations/relaxations_sparsity.json", "unipotent_n2_order1_dense")
         reg, (u,) = create_unipotent_variables([("u", 1:2)])
         objective = 1.0 * u[1] * u[2]
         pop = polyopt(objective, reg)
@@ -49,11 +50,12 @@ end
         )
         result = cs_nctssos(pop, config)
 
-        @test result.moment_matrix_sizes == [[3]]
-        @test result.n_unique_moment_matrix_elements == 4
+        @test flatten_sizes(result.moment_matrix_sizes) == oracle.sides
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 
     @testset "minimal single variable" begin
+        oracle = expectations_oracle("expectations/relaxations_sparsity.json", "unipotent_n1_order1_dense")
         reg, (u,) = create_unipotent_variables([("u", 1:1)])
         objective = 1.0 * u[1]
         pop = polyopt(objective, reg)
@@ -66,7 +68,7 @@ end
         )
         result = cs_nctssos(pop, config)
 
-        @test result.moment_matrix_sizes == [[2]]
-        @test result.n_unique_moment_matrix_elements == 2
+        @test flatten_sizes(result.moment_matrix_sizes) == oracle.sides
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,11 @@
 using NCTSSoS, Test
 
+include("Expectations.jl")
+using .TestExpectations: expectations_oracle
+
 @testset "NCTSSoS.jl" begin
+
+    include("expectations_loader.jl")
 
     # 1. Polynomial algebra (no solver)
     include("polynomials/runtests.jl")

--- a/test/state_poly/integration_chsh.jl
+++ b/test/state_poly/integration_chsh.jl
@@ -5,11 +5,7 @@
 
 using Test, NCTSSoS, JuMP
 
-# Oracle values from NCTSSOS
-const CHSH_STATE_ORACLES = (
-    Dense = (opt=-2.828427124746234, sides=[9], nuniq=21),
-    TS    = (opt=-2.8284271247321175, nuniq=10),  # sides vary by implementation
-)
+# Expectations in test/data/expectations/chsh_state.json
 
 @testset "CHSH State Polynomial" begin
     reg, (x, y) = create_unipotent_variables([("x", 1:2), ("y", 1:2)])
@@ -17,6 +13,7 @@ const CHSH_STATE_ORACLES = (
     spop = polyopt(sp * one(typeof(x[1])), reg)
 
     @testset "Dense" begin
+        oracle = expectations_oracle("expectations/chsh_state.json", "Dense")
         config = SolverConfig(
             optimizer=SOLVER,
             order=1,
@@ -24,12 +21,13 @@ const CHSH_STATE_ORACLES = (
             ts_algo=NoElimination()
         )
         result = cs_nctssos(spop, config)
-        @test result.objective ≈ CHSH_STATE_ORACLES.Dense.opt atol = 1e-5
-        @test flatten_sizes(result.moment_matrix_sizes) == CHSH_STATE_ORACLES.Dense.sides
-        @test result.n_unique_moment_matrix_elements == CHSH_STATE_ORACLES.Dense.nuniq
+        @test result.objective ≈ oracle.opt atol = 1e-5
+        @test flatten_sizes(result.moment_matrix_sizes) == oracle.sides
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 
     @testset "Term Sparsity (MMD)" begin
+        oracle = expectations_oracle("expectations/chsh_state.json", "TS")
         config = SolverConfig(
             optimizer=SOLVER,
             order=1,
@@ -37,7 +35,7 @@ const CHSH_STATE_ORACLES = (
             ts_algo=MMD()
         )
         result = cs_nctssos(spop, config)
-        @test result.objective ≈ CHSH_STATE_ORACLES.TS.opt atol = 1e-5
-        @test result.n_unique_moment_matrix_elements == CHSH_STATE_ORACLES.TS.nuniq
+        @test result.objective ≈ oracle.opt atol = 1e-5
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 end

--- a/test/trace_poly/chsh_trace.jl
+++ b/test/trace_poly/chsh_trace.jl
@@ -5,11 +5,7 @@
 
 using Test, NCTSSoS, JuMP
 
-# Oracle values from NCTSSOS
-const CHSH_TRACE_ORACLES = (
-    Dense = (opt=-2.828427124746234, sides=[9], nuniq=21),
-    TS    = (opt=-2.8284271247321175, nuniq=10),  # sides vary by implementation
-)
+# Expectations in test/data/expectations/chsh_trace.json
 
 @testset "CHSH Trace Polynomial" begin
     reg, (vars,) = create_unipotent_variables([("v", 1:4)])
@@ -28,6 +24,7 @@ const CHSH_TRACE_ORACLES = (
     tpop = polyopt(p * one(typeof(x[1])), reg)
 
     @testset "Dense" begin
+        oracle = expectations_oracle("expectations/chsh_trace.json", "Dense")
         config = SolverConfig(
             optimizer=SOLVER,
             order=1,
@@ -35,12 +32,13 @@ const CHSH_TRACE_ORACLES = (
             ts_algo=NoElimination()
         )
         result = cs_nctssos(tpop, config)
-        @test result.objective ≈ CHSH_TRACE_ORACLES.Dense.opt atol = 1e-5
-        @test flatten_sizes(result.moment_matrix_sizes) == CHSH_TRACE_ORACLES.Dense.sides
-        @test result.n_unique_moment_matrix_elements == CHSH_TRACE_ORACLES.Dense.nuniq
+        @test result.objective ≈ oracle.opt atol = 1e-5
+        @test flatten_sizes(result.moment_matrix_sizes) == oracle.sides
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 
     @testset "Term Sparsity (MMD)" begin
+        oracle = expectations_oracle("expectations/chsh_trace.json", "TS")
         config = SolverConfig(
             optimizer=SOLVER,
             order=1,
@@ -48,7 +46,7 @@ const CHSH_TRACE_ORACLES = (
             ts_algo=MMD()
         )
         result = cs_nctssos(tpop, config)
-        @test result.objective ≈ CHSH_TRACE_ORACLES.TS.opt atol = 1e-5
-        @test result.n_unique_moment_matrix_elements == CHSH_TRACE_ORACLES.TS.nuniq
+        @test result.objective ≈ oracle.opt atol = 1e-5
+        @test result.n_unique_moment_matrix_elements == oracle.nuniq
     end
 end


### PR DESCRIPTION
## Summary

- Move solver-dependent numeric "oracle" expectations into tracked JSON fixtures under `test/data/expectations/`
- Add `TestExpectations` helper module for loading fixtures by stable `id`
- Migrate 7 test files to use fixture-based oracles instead of hard-coded constants
- Mirror the pattern in docs: trace polynomial example reads reference values from `docs/src/examples/literate/data/trace_poly_refs.json`
- Wire `JSON3` as test + docs dependency; update `.gitignore` to un-ignore fixture paths

## Diffstat

`29 files changed, 389 insertions(+), 72 deletions(-)`

## Verification

- `make test` exit: `0`
- Test Summary: `2294 Pass, 2 Broken, 1m32.9s`
- 2 broken tests are pre-existing (`test/correlated_sparsity/literature_matrix.jl:33-34`)

## Review

See full change brief: `review/explain-changes-brief-issue-272-update-plan-20260227-165642.md`

### Sites Changed

1. **Test Expectations Framework** — new `test/Expectations.jl` module, loader test, 10 JSON fixtures, schema docs
2. **Solver-Dependent Tests Migrated to JSON** — 7 test files switch from hard-coded oracles to `expectations_oracle()` calls
3. **Docs Example Stabilized via JSON Refs** — trace poly Literate source reads reference values from JSON
4. **Packaging / Ignore Rules** — `.gitignore` negations for fixture dirs, `JSON3` added to `Project.toml` + `docs/Project.toml`

### Known Follow-ups

- #282 — simplify `TestExpectations` module to plain functions
- #283 — add provenance guardrails for fixture value changes
- #284 — inline actual numeric values in docs example assertions
- #285 — fix mutagen sync gap + verify gitignore negation patterns

## How to Test

```bash
make test
```