### PR TITLE
feat(symmetry): add fermionic symmetry-adapted basis reductions

### DIFF
--- a/src/NCTSSoS.jl
+++ b/src/NCTSSoS.jl
@@ -128,6 +128,8 @@ include("optimization/v2rdm_structured.jl")
 include("optimization/moment.jl")
 include("optimization/lowering.jl")
 include("optimization/symmetry.jl")
+include("optimization/fermionic_irreps.jl")
+include("optimization/fermionic_spin.jl")
 include("optimization/sos.jl")
 include("optimization/interface.jl")
 include("optimization/gns.jl")
@@ -141,7 +143,9 @@ include("optimization/gns_diagnostics.jl")
 
 # Problem Definition
 export PolyOpt, polyopt, PolyOptResult, SolverConfig
-export SignedPermutation, SymmetrySpec, SymmetryReport
+export SignedPermutation, FermionicModePermutation, FermionicModeLayout, AbelianIrrepTable
+export FermionicSectorSpec, FermionicSectorLabel, FermionicSpinAdaptationSpec, FermionicSpinBlockLabel
+export SymmetrySpec, SymmetryReport
 export SparsityResult, compute_sparsity
 
 # Solver Interface

--- a/src/optimization/fermionic_irreps.jl
+++ b/src/optimization/fermionic_irreps.jl
@@ -1,0 +1,109 @@
+function _fermionic_irrep_table(sector::FermionicSectorSpec)
+    table = sector.mode_layout.irrep_table
+    isnothing(table) && throw(ArgumentError(
+        "`split_irrep=true` needs an explicit `irrep_table` in the supplied `FermionicModeLayout`."
+    ))
+    return table
+end
+
+@inline _fermionic_irrep_identity(sector::FermionicSectorSpec) = _fermionic_irrep_table(sector).identity
+@inline _fermionic_irrep_multiply(sector::FermionicSectorSpec, left, right) =
+    _fermionic_irrep_table(sector).multiply(left, right)
+@inline _fermionic_irrep_dual(sector::FermionicSectorSpec, irrep) =
+    _fermionic_irrep_table(sector).dual(irrep)
+
+function _fermionic_mode_orbital(mode_layout::FermionicModeLayout, mode::Int; context::AbstractString="Fermionic orbital metadata")
+    haskey(mode_layout.orbital_of, mode) || throw(ArgumentError(
+        "$context needs `orbital_of[$mode]` in the supplied `FermionicModeLayout`."
+    ))
+    return mode_layout.orbital_of[mode]
+end
+
+function _fermionic_mode_orbital(sector::FermionicSectorSpec, mode::Int)
+    return _fermionic_mode_orbital(
+        sector.mode_layout,
+        mode;
+        context="Fermionic irrep-sector splitting",
+    )
+end
+
+function _fermionic_orbital_irrep(mode_layout::FermionicModeLayout, orbital::Int; context::AbstractString="Fermionic orbital metadata")
+    haskey(mode_layout.irrep_of, orbital) || throw(ArgumentError(
+        "$context needs `irrep_of[$orbital]` in the supplied `FermionicModeLayout`."
+    ))
+    return mode_layout.irrep_of[orbital]
+end
+
+function _fermionic_mode_irrep(sector::FermionicSectorSpec, mode::Int)
+    orbital = _fermionic_mode_orbital(sector, mode)
+    return _fermionic_orbital_irrep(
+        sector.mode_layout,
+        orbital;
+        context="Fermionic irrep-sector splitting",
+    )
+end
+
+function _validate_abelian_irrep_table(table::AbelianIrrepTable, irreps::AbstractVector)
+    dual_irreps = [table.dual(irrep) for irrep in irreps]
+    values = unique!(Any[table.identity; irreps; dual_irreps])
+
+    for irrep in values
+        table.multiply(table.identity, irrep) == irrep || throw(ArgumentError(
+            "`AbelianIrrepTable` identity must act neutrally on the left; failed for irrep $(repr(irrep))."
+        ))
+        table.multiply(irrep, table.identity) == irrep || throw(ArgumentError(
+            "`AbelianIrrepTable` identity must act neutrally on the right; failed for irrep $(repr(irrep))."
+        ))
+
+        dual_irrep = table.dual(irrep)
+        table.dual(dual_irrep) == irrep || throw(ArgumentError(
+            "`AbelianIrrepTable` dual must be involutive; failed for irrep $(repr(irrep))."
+        ))
+        table.multiply(irrep, dual_irrep) == table.identity || throw(ArgumentError(
+            "`AbelianIrrepTable` dual must invert on the right; failed for irrep $(repr(irrep))."
+        ))
+        table.multiply(dual_irrep, irrep) == table.identity || throw(ArgumentError(
+            "`AbelianIrrepTable` dual must invert on the left; failed for irrep $(repr(irrep))."
+        ))
+    end
+
+    for left in values, right in values
+        table.multiply(left, right) == table.multiply(right, left) || throw(ArgumentError(
+            "`AbelianIrrepTable` must be Abelian on the supplied active irreps; failed for $(repr(left)) and $(repr(right))."
+        ))
+    end
+
+    return nothing
+end
+
+function _validate_active_fermionic_sector_metadata(
+    sector::FermionicSectorSpec,
+    active_modes::AbstractVector{<:Integer},
+)
+    if sector.split_spin
+        for mode in active_modes
+            haskey(sector.mode_layout.spin2_of, mode) || throw(ArgumentError(
+                "Fermionic spin-sector splitting needs `spin2_of[$mode]` for every active mode."
+            ))
+        end
+    end
+
+    sector.split_irrep || return nothing
+
+    active_orbitals = Int[]
+    sizehint!(active_orbitals, length(active_modes))
+    for mode in active_modes
+        push!(active_orbitals, _fermionic_mode_orbital(sector, Int(mode)))
+    end
+    unique!(sort!(active_orbitals))
+
+    for orbital in active_orbitals
+        haskey(sector.mode_layout.irrep_of, orbital) || throw(ArgumentError(
+            "`split_irrep=true` needs `irrep_of[$orbital]` for every active orbital."
+        ))
+    end
+
+    active_irreps = Any[_fermionic_orbital_irrep(sector.mode_layout, orbital) for orbital in active_orbitals]
+    _validate_abelian_irrep_table(_fermionic_irrep_table(sector), active_irreps)
+    return nothing
+end

--- a/src/optimization/fermionic_spin.jl
+++ b/src/optimization/fermionic_spin.jl
@@ -1,0 +1,360 @@
+"""
+    FermionicSpinBlockLabel
+
+Label attached to one Casimir-adapted SU(2) block produced by
+[`FermionicSpinAdaptationSpec`](@ref). Carries:
+
+- `sector::FermionicSectorLabel` — the underlying fermionic-sector label
+  the SU(2) split was layered on top of.
+- `total_spin2::Int` — twice the total spin quantum number `2 S` (so
+  `0` = singlet `S = 0`, `1` = doublet `S = 1/2`, `2` = triplet
+  `S = 1`, ...). The associated Casimir eigenvalue is
+  `S(S+1) = total_spin2 * (total_spin2 + 2) / 4`.
+- `multiplicity_tag::Int` — opaque tag distinguishing equivalent SU(2)
+  blocks of the same total spin within the same sector.
+"""
+struct FermionicSpinBlockLabel
+    sector::FermionicSectorLabel
+    total_spin2::Int
+    multiplicity_tag::Int
+end
+
+function Base.show(io::IO, label::FermionicSpinBlockLabel)
+    print(
+        io,
+        "FermionicSpinBlockLabel(sector=$(label.sector), total_spin2=$(label.total_spin2), multiplicity_tag=$(label.multiplicity_tag))",
+    )
+end
+
+function _validate_matching_mode_layouts(
+    sector_layout::FermionicModeLayout,
+    spin_layout::FermionicModeLayout,
+    active_modes::AbstractVector{<:Integer},
+)
+    for mode_raw in active_modes
+        mode = Int(mode_raw)
+        _fermionic_mode_orbital(sector_layout, mode; context="Fermionic spin adaptation") ==
+            _fermionic_mode_orbital(spin_layout, mode; context="Fermionic spin adaptation") || throw(ArgumentError(
+                "Fermionic spin adaptation needs `mode_layout.orbital_of[$mode]` to match the fermionic sector metadata."
+            ))
+
+        sector_spin = get(sector_layout.spin2_of, mode, nothing)
+        spin_spin = get(spin_layout.spin2_of, mode, nothing)
+        sector_spin == spin_spin || throw(ArgumentError(
+            "Fermionic spin adaptation needs `mode_layout.spin2_of[$mode]` to match the fermionic sector metadata."
+        ))
+    end
+
+    return nothing
+end
+
+function _validate_fermionic_spin_generators(
+    generators::AbstractVector{<:FermionicModePermutation},
+    mode_layout::FermionicModeLayout,
+    active_modes::AbstractVector{<:Integer},
+)
+    for g in generators, mode_raw in active_modes
+        mode = Int(mode_raw)
+        dst = get(g.images, mode, mode)
+        get(mode_layout.spin2_of, dst, nothing) == get(mode_layout.spin2_of, mode, nothing) || throw(ArgumentError(
+            "Fermionic spin adaptation currently requires every `FermionicModePermutation` to preserve spin labels on active modes."
+        ))
+    end
+    return nothing
+end
+
+function _fermionic_spin_orbital_pairs(
+    mode_layout::FermionicModeLayout,
+    active_modes::AbstractVector{<:Integer},
+)
+    by_orbital = Dict{Int,Dict{Int,Int}}()
+
+    for mode_raw in active_modes
+        mode = Int(mode_raw)
+        orbital = _fermionic_mode_orbital(mode_layout, mode; context="Fermionic spin adaptation")
+        spin2 = get(mode_layout.spin2_of, mode, nothing)
+        isnothing(spin2) && throw(ArgumentError(
+            "Fermionic spin adaptation needs `spin2_of[$mode]` for every active mode."
+        ))
+        spin2 in (-1, 1) || throw(ArgumentError(
+            "Fermionic spin adaptation currently supports only spin-1/2 doublets encoded by `spin2_of[mode] ∈ {-1, +1}`. Got $spin2 for mode $mode."
+        ))
+
+        bucket = get!(by_orbital, orbital, Dict{Int,Int}())
+        haskey(bucket, spin2) && bucket[spin2] != mode && throw(ArgumentError(
+            "Fermionic spin adaptation needs exactly one active mode per `(orbital, spin)` pair. Orbital $orbital has duplicate spin label $spin2."
+        ))
+        bucket[spin2] = mode
+    end
+
+    pairs = Pair{Int,Tuple{Int,Int}}[]
+    for orbital in sort!(collect(keys(by_orbital)))
+        bucket = by_orbital[orbital]
+        haskey(bucket, 1) && haskey(bucket, -1) || throw(ArgumentError(
+            "Fermionic spin adaptation needs a complete `(↑, ↓)` doublet for every active orbital. Orbital $orbital is incomplete."
+        ))
+        push!(pairs, orbital => (bucket[1], bucket[-1]))
+    end
+
+    return pairs
+end
+
+function _validate_fermionic_spin_adaptation_spec(
+    symmetry::SymmetrySpec,
+    active_modes::AbstractVector{<:Integer},
+)
+    spin_adaptation = symmetry.spin_adaptation
+    isnothing(spin_adaptation) && return nothing
+
+    sector = symmetry.sector
+    isnothing(sector) && throw(ArgumentError(
+        "Fermionic spin adaptation needs a fermionic sector split; supply `sector=FermionicSectorSpec(..., split_spin=true)` as well."
+    ))
+    sector.split_spin || throw(ArgumentError(
+        "Fermionic spin adaptation needs `split_spin=true` in the supplied `FermionicSectorSpec`."
+    ))
+    spin_adaptation.casimir_tol > 0 || throw(ArgumentError(
+        "`FermionicSpinAdaptationSpec.casimir_tol` must be positive."
+    ))
+    spin_adaptation.compress_multiplets && throw(ArgumentError(
+        "`compress_multiplets=true` is not implemented yet; keep multiplicity explicit for now."
+    ))
+
+    _validate_matching_mode_layouts(sector.mode_layout, spin_adaptation.mode_layout, active_modes)
+    _validate_fermionic_spin_generators(
+        symmetry.fermionic_generators,
+        spin_adaptation.mode_layout,
+        active_modes,
+    )
+    _fermionic_spin_orbital_pairs(spin_adaptation.mode_layout, active_modes)
+
+    return nothing
+end
+
+@inline _fermionic_mode_operator(::Type{T}, idx::Integer) where {T<:Integer} =
+    NormalMonomial{FermionicAlgebra,T}(T[idx])
+
+function _fermionic_total_spin_operators(
+    ::Type{T},
+    spin_adaptation::FermionicSpinAdaptationSpec,
+    active_modes::AbstractVector{<:Integer},
+) where {T<:Integer}
+    pairs = _fermionic_spin_orbital_pairs(spin_adaptation.mode_layout, active_modes)
+    isempty(pairs) && throw(ArgumentError("Fermionic spin adaptation needs at least one active spin doublet."))
+
+    up_probe, dn_probe = last(first(pairs))
+    probe_poly = _fermionic_mode_operator(T, -up_probe) * _fermionic_mode_operator(T, up_probe)
+    sz = zero(probe_poly)
+    splus = zero(probe_poly)
+    sminus = zero(probe_poly)
+
+    for (_, (up_mode, dn_mode)) in pairs
+        up = _fermionic_mode_operator(T, up_mode)
+        dn = _fermionic_mode_operator(T, dn_mode)
+        up_dag = _fermionic_mode_operator(T, -up_mode)
+        dn_dag = _fermionic_mode_operator(T, -dn_mode)
+
+        sz += 0.5 * (up_dag * up - dn_dag * dn)
+        splus += up_dag * dn
+        sminus += dn_dag * up
+    end
+
+    return sz, splus, sminus
+end
+
+@inline _adjoint_action(op::Polynomial{FermionicAlgebra,T,C}, mono::NormalMonomial{FermionicAlgebra,T}) where {T<:Integer,C<:Number} =
+    op * mono - mono * op
+@inline _adjoint_action(op::Polynomial{FermionicAlgebra,T,C1}, poly::Polynomial{FermionicAlgebra,T,C2}) where {T<:Integer,C1<:Number,C2<:Number} =
+    op * poly - poly * op
+
+function _fermionic_polynomial_coordinate_vector(
+    poly::Polynomial{FermionicAlgebra,T,C},
+    basis_index::Dict{NormalMonomial{FermionicAlgebra,T},Int},
+    context::AbstractString;
+    atol::Float64=_SYMMETRY_ATOL,
+) where {T<:Integer,C<:Number}
+    coords = zeros(ComplexF64, length(basis_index))
+    for (coef, mono) in poly.terms
+        idx = get(basis_index, mono, 0)
+        if idx == 0
+            abs(coef) <= atol || throw(ArgumentError(
+                "$context leaves the supplied basis. Missing basis element $mono with coefficient $coef."
+            ))
+        else
+            coords[idx] += coef
+        end
+    end
+    return coords
+end
+
+function _fermionic_spin_casimir_matrix(
+    sector_basis::AbstractVector{<:NormalMonomial{FermionicAlgebra,T}},
+    spin_adaptation::FermionicSpinAdaptationSpec,
+    active_modes::AbstractVector{<:Integer};
+    atol::Float64=_SYMMETRY_ATOL,
+    context::AbstractString="fermionic spin block",
+) where {T<:Integer}
+    sz, splus, sminus = _fermionic_total_spin_operators(T, spin_adaptation, active_modes)
+    basis_index = Dict{NormalMonomial{FermionicAlgebra,T},Int}(mono => idx for (idx, mono) in enumerate(sector_basis))
+    casimir = zeros(ComplexF64, length(sector_basis), length(sector_basis))
+
+    for (col, mono) in enumerate(sector_basis)
+        acted = _adjoint_action(sz, _adjoint_action(sz, mono)) +
+            0.5 * (
+                _adjoint_action(splus, _adjoint_action(sminus, mono)) +
+                _adjoint_action(sminus, _adjoint_action(splus, mono))
+            )
+        casimir[:, col] .= _fermionic_polynomial_coordinate_vector(
+            acted,
+            basis_index,
+            "$context Casimir action on basis element $col";
+            atol,
+        )
+    end
+
+    return 0.5 * (casimir + casimir')
+end
+
+function _group_eigenvalue_indices(values::AbstractVector{<:Real}, tol::Real)
+    isempty(values) && return Vector{UnitRange{Int}}()
+
+    groups = UnitRange{Int}[]
+    start = 1
+    for idx in 2:length(values)
+        if abs(values[idx] - values[idx - 1]) > tol
+            push!(groups, start:(idx - 1))
+            start = idx
+        end
+    end
+    push!(groups, start:length(values))
+    return groups
+end
+
+function _normalize_phase!(vec::AbstractVector{ComplexF64}; atol::Float64=_SYMMETRY_ATOL)
+    for entry in vec
+        abs(entry) > atol || continue
+        vec ./= entry / abs(entry)
+        return vec
+    end
+    return vec
+end
+
+function _canonical_eigenspace_row_basis(
+    eigvecs::AbstractMatrix{<:Number};
+    atol::Float64=_SYMMETRY_ATOL,
+)
+    projector = ComplexF64.(eigvecs) * ComplexF64.(eigvecs)'
+    qcols = Matrix{ComplexF64}(undef, size(projector, 1), 0)
+
+    for col in axes(projector, 2)
+        candidate = projector[:, col]
+        if size(qcols, 2) > 0
+            candidate -= qcols * (qcols' * candidate)
+            candidate -= qcols * (qcols' * candidate)
+        end
+
+        norm_candidate = norm(candidate)
+        norm_candidate > atol || continue
+        candidate ./= norm_candidate
+        _normalize_phase!(candidate; atol)
+        qcols = hcat(qcols, candidate)
+        size(qcols, 2) == size(eigvecs, 2) && break
+    end
+
+    size(qcols, 2) == size(eigvecs, 2) || throw(ArgumentError(
+        "Failed to build a deterministic basis for a degenerate SU(2) eigenspace of dimension $(size(eigvecs, 2))."
+    ))
+
+    return qcols'
+end
+
+function _casimir_eigenvalue_to_spin2(value::Real, tol::Real)
+    value < -tol && throw(ArgumentError(
+        "Encountered a negative SU(2) Casimir eigenvalue $value beyond tolerance $tol."
+    ))
+    twoS = round(Int, sqrt(max(0.0, 1 + 4 * value)) - 1)
+    expected = twoS * (twoS + 2) / 4
+    abs(value - expected) <= tol || throw(ArgumentError(
+        "Casimir eigenvalue $value does not match any exact `S(S+1)` value within tolerance $tol."
+    ))
+    return twoS
+end
+
+@inline _spin_transform_provenance(prev::Symbol) =
+    prev == :sector_wedderburn ? :sector_spin_wedderburn : :sector_spin
+
+function _fermionic_spin_transform_blocks(
+    sector_basis::AbstractVector{<:NormalMonomial{FermionicAlgebra,T}},
+    transform_blocks::Vector{<:_BasisTransformBlock},
+    sector_label::FermionicSectorLabel,
+    spin_adaptation::FermionicSpinAdaptationSpec,
+    active_modes::AbstractVector{<:Integer};
+    atol::Float64=_SYMMETRY_ATOL,
+    context::AbstractString="fermionic spin block",
+) where {T<:Integer}
+    casimir = _fermionic_spin_casimir_matrix(
+        sector_basis,
+        spin_adaptation,
+        active_modes;
+        atol,
+        context,
+    )
+    counts = Dict{Int,Int}()
+    adapted = _BasisTransformBlock[]
+
+    for block in transform_blocks
+        row_basis = ComplexF64.(block.row_basis)
+        restricted = 0.5 * (row_basis * casimir * row_basis' + (row_basis * casimir * row_basis')')
+        eig = eigen(Hermitian(restricted))
+        groups = _group_eigenvalue_indices(real.(eig.values), spin_adaptation.casimir_tol)
+
+        for group in groups
+            eigvalue = sum(real.(eig.values[group])) / length(group)
+            total_spin2 = _casimir_eigenvalue_to_spin2(eigvalue, spin_adaptation.casimir_tol)
+            local_row_basis = _canonical_eigenspace_row_basis(
+                eig.vectors[:, group];
+                atol=max(atol, spin_adaptation.casimir_tol),
+            )
+            multiplicity_tag = get(counts, total_spin2, 0) + 1
+            counts[total_spin2] = multiplicity_tag
+            push!(adapted, _BasisTransformBlock(
+                local_row_basis * row_basis,
+                FermionicSpinBlockLabel(sector_label, total_spin2, multiplicity_tag),
+                _spin_transform_provenance(block.provenance),
+            ))
+        end
+    end
+
+    return adapted
+end
+
+function _fermionic_sector_transform_blocks(
+    sector_basis::AbstractVector{<:NormalMonomial{FermionicAlgebra,T}},
+    sector_label::FermionicSectorLabel,
+    sw_group,
+    spin_adaptation::Union{Nothing,FermionicSpinAdaptationSpec},
+    active_modes::AbstractVector{<:Integer};
+    atol::Float64=_SYMMETRY_ATOL,
+    context::AbstractString="fermionic sector block",
+) where {T<:Integer}
+    n = length(sector_basis)
+    transform_blocks = if isnothing(sw_group) || n == 1
+        _BasisTransformBlock[_BasisTransformBlock(Matrix{Float64}(I, n, n), sector_label, :sector_split)]
+    else
+        _BasisTransformBlock[
+            _BasisTransformBlock(Matrix(block), sector_label, :sector_wedderburn)
+            for block in _sw_decompose_half_basis(collect(sector_basis), sw_group)
+        ]
+    end
+
+    isnothing(spin_adaptation) && return transform_blocks
+    return _fermionic_spin_transform_blocks(
+        sector_basis,
+        transform_blocks,
+        sector_label,
+        spin_adaptation,
+        active_modes;
+        atol,
+        context,
+    )
+end

--- a/src/optimization/interface.jl
+++ b/src/optimization/interface.jl
@@ -330,10 +330,12 @@ Configuration for solving polynomial optimization problems.
 - `cs_algo::EliminationAlgorithm`: Algorithm for correlative sparsity exploitation (default: NoElimination())
 - `ts_algo::EliminationAlgorithm`: Algorithm for term sparsity exploitation (default: NoElimination())
 - `symmetry::Union{Nothing,SymmetrySpec}`: Optional symmetry reduction spec. The
-  current MVP is intentionally narrow: dense ordinary polynomial relaxations only
-  (`cs_algo=NoElimination()`, `ts_algo=NoElimination()`), monoid algebras only,
-  and signed-permutation actions only. Unsupported combinations error instead of
-  silently doing the wrong thing.
+  current implementation is still intentionally narrow: dense ordinary polynomial
+  relaxations only (`cs_algo=NoElimination()`, `ts_algo=NoElimination()`), with
+  supported combinations limited to either
+  - `MonoidAlgebra` + `SignedPermutation`, or
+  - `FermionicAlgebra` + `FermionicModePermutation`, `FermionicSectorSpec`, and optional `FermionicSpinAdaptationSpec` layered on sector blocks.
+  Unsupported combinations error instead of silently doing the wrong thing.
 
 # Examples
 ```jldoctest; setup=:(using NCTSSoS, COSMO)
@@ -372,25 +374,45 @@ function _check_symmetry_mvp_support(
 ) where {A<:AlgebraType,P}
     isnothing(solver_config.symmetry) && return nothing
 
-    A <: MonoidAlgebra || throw(ArgumentError(
-        "Symmetry reduction MVP currently supports ordinary polynomial problems over `MonoidAlgebra` only. Got `$(nameof(A))`."
-    ))
+    symmetry = solver_config.symmetry
+
     P <: Polynomial || throw(ArgumentError(
-        "Symmetry reduction MVP currently supports ordinary polynomial problems only; state/trace problems are not yet supported."
+        "Symmetry reduction currently supports ordinary polynomial problems only; state/trace problems are not yet supported."
     ))
     solver_config.cs_algo isa NoElimination || throw(ArgumentError(
-        "Symmetry reduction MVP currently requires `cs_algo=NoElimination()`."
+        "Symmetry reduction currently requires `cs_algo=NoElimination()`."
     ))
     solver_config.ts_algo isa NoElimination || throw(ArgumentError(
-        "Symmetry reduction MVP currently requires `ts_algo=NoElimination()`."
+        "Symmetry reduction currently requires `ts_algo=NoElimination()`."
     ))
     length(sparsity.corr_sparsity.cliques) == 1 || throw(ArgumentError(
-        "Symmetry reduction MVP currently supports a single dense clique only."
+        "Symmetry reduction currently supports a single dense clique only."
     ))
 
     for term_sparsities in sparsity.cliques_term_sparsities, term_sparsity in term_sparsities
         length(term_sparsity.block_bases) == 1 || throw(ArgumentError(
-            "Symmetry reduction MVP does not yet compose with term-sparsity block splitting."
+            "Symmetry reduction does not yet compose with term-sparsity block splitting."
+        ))
+    end
+
+    if !isempty(symmetry.generators)
+        A <: MonoidAlgebra || throw(ArgumentError(
+            "`SignedPermutation` symmetry is currently supported only for ordinary polynomial problems over `MonoidAlgebra`. Got `$(nameof(A))`."
+        ))
+        (isnothing(symmetry.sector) && isnothing(symmetry.spin_adaptation)) || throw(ArgumentError(
+            "Fermionic sector splitting / spin adaptation cannot be combined with raw `SignedPermutation` symmetry. Use `FermionicModePermutation` for fermionic problems."
+        ))
+    end
+
+    if !isempty(symmetry.fermionic_generators) || !isnothing(symmetry.sector) || !isnothing(symmetry.spin_adaptation)
+        A === FermionicAlgebra || throw(ArgumentError(
+            "Fermionic mode permutations / sector splitting / spin adaptation are currently supported only for `FermionicAlgebra`. Got `$(nameof(A))`."
+        ))
+    end
+
+    if !isnothing(symmetry.spin_adaptation)
+        isnothing(symmetry.sector) && throw(ArgumentError(
+            "Fermionic spin adaptation currently requires `sector=FermionicSectorSpec(..., split_spin=true)` in the same `SymmetrySpec`."
         ))
     end
 

--- a/src/optimization/symmetry.jl
+++ b/src/optimization/symmetry.jl
@@ -95,37 +95,224 @@ function SignedPermutation(pairs::Pair...)
 end
 
 """
-    SymmetrySpec
+    FermionicModePermutation
 
-Symmetry configuration for the dense signed-permutation MVP.
+Finite permutation acting on physical fermionic modes.
 
-# Fields
-- `generators`: signed-permutation generators on registry indices
-- `check_invariance`: whether to fail fast on objective/constraint non-invariance
+Unlike `SignedPermutation`, this acts on unsigned physical mode ids. Creation vs
+annihilation is preserved by the operator action itself, and any reordering sign
+comes from re-normal-ordering the fermionic word.
 """
-@kwdef struct SymmetrySpec{T<:Integer}
-    generators::Vector{SignedPermutation{T}}
-    check_invariance::Bool = true
+struct FermionicModePermutation{T<:Integer}
+    images::Dict{T,T}
+
+    function FermionicModePermutation{T}(images::Dict{T,T}) where {T<:Integer}
+        normalized = Dict{T,T}()
+        for (src, dst) in images
+            src == dst || (normalized[src] = dst)
+        end
+        return new{T}(normalized)
+    end
 end
 
-function SymmetrySpec(generators::AbstractVector{<:SignedPermutation}; check_invariance::Bool=true)
-    isempty(generators) && throw(ArgumentError("`SymmetrySpec` needs at least one generator."))
+function FermionicModePermutation(images::AbstractDict{T,<:Integer}) where {T<:Integer}
+    normalized = Dict{T,T}()
+    for (src, dst) in images
+        normalized[src] = convert(T, dst)
+    end
+    return FermionicModePermutation{T}(normalized)
+end
 
-    T = Int
-    for generator in generators
-        for (src, (_, dst)) in generator.images
-            T = promote_type(T, typeof(src), typeof(dst))
-        end
+function FermionicModePermutation(pairs::Pair...)
+    isempty(pairs) && return FermionicModePermutation(Dict{Int,Int}())
+    parsed = Tuple{Integer,Integer}[]
+    for pair in pairs
+        src = _signed_permutation_require_integer(pair.first, "source mode")
+        dst = _signed_permutation_require_integer(pair.second, "target mode"; src)
+        push!(parsed, (src, dst))
     end
 
-    converted = SignedPermutation{T}[
-        _convert_signed_permutation(T, generator) for generator in generators
-    ]
-    return SymmetrySpec{T}(converted, check_invariance)
+    types = Type[]
+    for (src, dst) in parsed
+        push!(types, typeof(src), typeof(dst))
+    end
+    T = promote_type(types...)
+
+    images = Dict{T,T}()
+    for (src, dst) in parsed
+        images[convert(T, src)] = convert(T, dst)
+    end
+    return FermionicModePermutation(images)
+end
+
+"""
+    AbelianIrrepTable
+
+Explicit Abelian irrep composition rules used by fermionic sector splitting.
+"""
+struct AbelianIrrepTable{Γ,M,D}
+    identity::Γ
+    multiply::M
+    dual::D
+end
+
+function AbelianIrrepTable(identity::Γ; multiply, dual=(x -> x)) where {Γ}
+    return AbelianIrrepTable{Γ,typeof(multiply),typeof(dual)}(identity, multiply, dual)
+end
+
+"""
+    FermionicModeLayout
+
+Explicit metadata for fermionic spin-orbitals used by the symmetry layer.
+"""
+struct FermionicModeLayout
+    orbital_of::Dict{Int,Int}
+    spin2_of::Dict{Int,Int}
+    irrep_of::Dict{Int,Any}
+    irrep_table::Union{Nothing,AbelianIrrepTable}
+end
+
+function FermionicModeLayout(
+    orbital_of::AbstractDict{<:Integer,<:Integer}=Dict{Int,Int}();
+    spin2_of::AbstractDict{<:Integer,<:Integer}=Dict{Int,Int}(),
+    irrep_of::AbstractDict{<:Integer,<:Any}=Dict{Int,Any}(),
+    irrep_table::Union{Nothing,AbelianIrrepTable}=nothing,
+)
+    orbitals = Dict{Int,Int}(Int(mode) => Int(orbital) for (mode, orbital) in orbital_of)
+    spins = Dict{Int,Int}(Int(mode) => Int(spin2) for (mode, spin2) in spin2_of)
+    irreps = Dict{Int,Any}(Int(orbital) => irrep for (orbital, irrep) in irrep_of)
+    return FermionicModeLayout(orbitals, spins, irreps, irrep_table)
+end
+
+"""
+    FermionicSectorSpec
+
+Sector-splitting specification for fermionic symmetry reduction.
+"""
+@kwdef struct FermionicSectorSpec
+    mode_layout::FermionicModeLayout = FermionicModeLayout()
+    split_parity::Bool = true
+    split_number::Bool = false
+    split_spin::Bool = false
+    split_irrep::Bool = false
+end
+
+"""
+    FermionicSpinAdaptationSpec
+
+Casimir-based SU(2) basis adaptation layered on top of fermionic sector splits.
+"""
+@kwdef struct FermionicSpinAdaptationSpec
+    mode_layout::FermionicModeLayout = FermionicModeLayout()
+    casimir_tol::Float64 = 1e-8
+    compress_multiplets::Bool = false
+end
+
+"""
+    FermionicSectorLabel
+
+Quantum-number label for a fermionic basis element under the enabled sector split.
+Disabled quantum numbers are stored as `nothing`.
+"""
+struct FermionicSectorLabel
+    parity::Union{Nothing,Int}
+    number::Union{Nothing,Int}
+    spin2::Union{Nothing,Int}
+    irrep
+end
+
+"""
+    SymmetrySpec
+
+Symmetry configuration for dense ordinary polynomial relaxations.
+
+Supported pieces today:
+- signed permutations on monoid-algebra registry indices;
+- fermionic mode permutations on physical modes;
+- fermionic sector splitting by parity / particle number / `S_z` / Abelian irreps;
+- fermionic SU(2) spin adaptation layered on top of fixed-sector blocks.
+
+Unsupported combinations fail loudly instead of quietly doing nonsense.
+"""
+struct SymmetrySpec
+    generators::Vector{SignedPermutation}
+    fermionic_generators::Vector{FermionicModePermutation}
+    sector::Union{Nothing,FermionicSectorSpec}
+    spin_adaptation::Union{Nothing,FermionicSpinAdaptationSpec}
+    check_invariance::Bool
+
+    function SymmetrySpec(
+        generators::Vector{SignedPermutation},
+        fermionic_generators::Vector{FermionicModePermutation},
+        sector::Union{Nothing,FermionicSectorSpec},
+        spin_adaptation::Union{Nothing,FermionicSpinAdaptationSpec},
+        check_invariance::Bool,
+    )
+        isempty(generators) && isempty(fermionic_generators) && isnothing(sector) && isnothing(spin_adaptation) && throw(ArgumentError(
+            "`SymmetrySpec` needs at least one finite action, fermionic sector split, or spin adaptation."
+        ))
+        !isempty(generators) && (!isempty(fermionic_generators) || !isnothing(sector) || !isnothing(spin_adaptation)) && throw(ArgumentError(
+            "`SymmetrySpec` does not yet support mixing raw `SignedPermutation` actions with fermionic mode permutations, sector splitting, or spin adaptation in the same spec."
+        ))
+        return new(generators, fermionic_generators, sector, spin_adaptation, check_invariance)
+    end
+end
+
+function SymmetrySpec(
+    generators::AbstractVector{<:SignedPermutation};
+    check_invariance::Bool=true,
+)
+    isempty(generators) && throw(ArgumentError("`SymmetrySpec` needs at least one generator."))
+    converted = SignedPermutation[generator for generator in generators]
+    return SymmetrySpec(converted, FermionicModePermutation[], nothing, nothing, check_invariance)
 end
 
 function SymmetrySpec(generators::SignedPermutation...; check_invariance::Bool=true)
     return SymmetrySpec(collect(generators); check_invariance)
+end
+
+function SymmetrySpec(
+    fermionic_generators::AbstractVector{<:FermionicModePermutation};
+    sector::Union{Nothing,FermionicSectorSpec}=nothing,
+    spin_adaptation::Union{Nothing,FermionicSpinAdaptationSpec}=nothing,
+    check_invariance::Bool=true,
+)
+    isempty(fermionic_generators) && isnothing(sector) && isnothing(spin_adaptation) && throw(ArgumentError(
+        "`SymmetrySpec` needs at least one fermionic mode permutation, sector split, or spin adaptation."
+    ))
+    converted = FermionicModePermutation[generator for generator in fermionic_generators]
+    return SymmetrySpec(SignedPermutation[], converted, sector, spin_adaptation, check_invariance)
+end
+
+function SymmetrySpec(
+    fermionic_generators::FermionicModePermutation...;
+    sector::Union{Nothing,FermionicSectorSpec}=nothing,
+    spin_adaptation::Union{Nothing,FermionicSpinAdaptationSpec}=nothing,
+    check_invariance::Bool=true,
+)
+    return SymmetrySpec(
+        collect(fermionic_generators);
+        sector=sector,
+        spin_adaptation=spin_adaptation,
+        check_invariance=check_invariance,
+    )
+end
+
+function SymmetrySpec(
+    ;
+    generators::AbstractVector{<:SignedPermutation}=SignedPermutation[],
+    fermionic_generators::AbstractVector{<:FermionicModePermutation}=FermionicModePermutation[],
+    sector::Union{Nothing,FermionicSectorSpec}=nothing,
+    spin_adaptation::Union{Nothing,FermionicSpinAdaptationSpec}=nothing,
+    check_invariance::Bool=true,
+)
+    return SymmetrySpec(
+        SignedPermutation[generator for generator in generators],
+        FermionicModePermutation[generator for generator in fermionic_generators],
+        sector,
+        spin_adaptation,
+        check_invariance,
+    )
 end
 
 """
@@ -139,6 +326,26 @@ struct SymmetryReport
     psd_block_sizes::Vector{Int}
     basis_half_size::Int
     basis_full_size::Int
+    block_labels::Vector{Any}
+    block_provenance::Vector{Symbol}
+end
+
+function SymmetryReport(
+    group_order::Int,
+    invariant_moment_count::Int,
+    psd_block_sizes::Vector{Int},
+    basis_half_size::Int,
+    basis_full_size::Int,
+)
+    return SymmetryReport(
+        group_order,
+        invariant_moment_count,
+        psd_block_sizes,
+        basis_half_size,
+        basis_full_size,
+        Any[],
+        Symbol[],
+    )
 end
 
 function Base.show(io::IO, report::SymmetryReport)
@@ -148,7 +355,8 @@ function Base.show(io::IO, report::SymmetryReport)
         "invariant_moment_count=$(report.invariant_moment_count), " *
         "psd_block_sizes=$(report.psd_block_sizes), " *
         "basis_half_size=$(report.basis_half_size), " *
-        "basis_full_size=$(report.basis_full_size))"
+        "basis_full_size=$(report.basis_full_size), " *
+        "block_provenance=$(report.block_provenance))"
     )
 end
 
@@ -161,25 +369,30 @@ struct NCWordSignedPermutationAction{A<:MonoidAlgebra,T<:Integer} <: SymbolicWed
     algebra::Type{A}
 end
 
-struct _SignedPermutationGroup{T<:Integer} <: GroupsCore.Group
+struct NCFermionicModePermutationAction{T<:Integer} <: SymbolicWedderburn.BySignedPermutations end
+
+struct _FiniteSymmetryGroup{G,T<:Integer} <: GroupsCore.Group
     domain::Vector{T}
-    elements::Vector{SignedPermutation{T}}
+    elements::Vector{G}
     generator_indices::Vector{Int}
     mult_table::Matrix{Int}
     inv_table::Vector{Int}
     element_orders::Vector{Int}
 end
 
-struct _SignedPermutationGroupElement{T<:Integer} <: GroupsCore.GroupElement
-    group::_SignedPermutationGroup{T}
+struct _FiniteSymmetryGroupElement{G,T<:Integer} <: GroupsCore.GroupElement
+    group::_FiniteSymmetryGroup{G,T}
     index::Int
 end
 
+const _SignedPermutationGroup{T} = _FiniteSymmetryGroup{SignedPermutation{T},T}
+const _SignedPermutationGroupElement{T} = _FiniteSymmetryGroupElement{SignedPermutation{T},T}
+const _FermionicModePermutationGroup{T} = _FiniteSymmetryGroup{FermionicModePermutation{T},T}
+const _FermionicModePermutationGroupElement{T} = _FiniteSymmetryGroupElement{FermionicModePermutation{T},T}
+
 @inline _signed_image(g::SignedPermutation{T}, idx::T) where {T<:Integer} = get(g.images, idx, (1, idx))
-@inline _signed_image_signature(g::SignedPermutation{T}, idx::T) where {T<:Integer} = begin
-    sign, dst = _signed_image(g, idx)
-    return sign * Int(dst)
-end
+@inline _signed_image_signature(g::SignedPermutation{T}, idx::T) where {T<:Integer} = _signed_image(g, idx)
+@inline _mode_image(g::FermionicModePermutation{T}, idx::T) where {T<:Integer} = get(g.images, idx, idx)
 
 function _convert_signed_permutation(::Type{T}, g::SignedPermutation) where {T<:Integer}
     images = Dict{T,Tuple{Int,T}}()
@@ -189,9 +402,24 @@ function _convert_signed_permutation(::Type{T}, g::SignedPermutation) where {T<:
     return SignedPermutation(images)
 end
 
+function _convert_fermionic_mode_permutation(::Type{T}, g::FermionicModePermutation) where {T<:Integer}
+    images = Dict{T,T}()
+    for (src, dst) in g.images
+        images[convert(T, src)] = convert(T, dst)
+    end
+    return FermionicModePermutation(images)
+end
+
 function _convert_symmetry_spec(::Type{T}, spec::SymmetrySpec) where {T<:Integer}
-    converted = SignedPermutation{T}[_convert_signed_permutation(T, g) for g in spec.generators]
-    return SymmetrySpec{T}(converted, spec.check_invariance)
+    converted = SignedPermutation[_convert_signed_permutation(T, g) for g in spec.generators]
+    fermionic = FermionicModePermutation[_convert_fermionic_mode_permutation(Int, g) for g in spec.fermionic_generators]
+    return SymmetrySpec(
+        generators=converted,
+        fermionic_generators=fermionic,
+        sector=spec.sector,
+        spin_adaptation=spec.spin_adaptation,
+        check_invariance=spec.check_invariance,
+    )
 end
 
 function _validate_signed_permutation(g::SignedPermutation{T}, domain::AbstractVector{T}) where {T<:Integer}
@@ -217,6 +445,29 @@ function _validate_signed_permutation(g::SignedPermutation{T}, domain::AbstractV
     return nothing
 end
 
+function _validate_fermionic_mode_permutation(
+    g::FermionicModePermutation{T},
+    domain::AbstractVector{T},
+) where {T<:Integer}
+    domain_set = Set(domain)
+    targets = T[]
+    sizehint!(targets, length(domain))
+
+    for idx in domain
+        dst = _mode_image(g, idx)
+        dst in domain_set || throw(ArgumentError(
+            "FermionicModePermutation sends mode $idx outside the active symmetry domain: $dst."
+        ))
+        push!(targets, dst)
+    end
+
+    length(unique(targets)) == length(domain) || throw(ArgumentError(
+        "FermionicModePermutation must be bijective on the active symmetry domain."
+    ))
+
+    return nothing
+end
+
 function _compose_signed_permutations(
     left::SignedPermutation{T},
     right::SignedPermutation{T},
@@ -234,29 +485,96 @@ function _compose_signed_permutations(
     return SignedPermutation(images)
 end
 
+function _compose_fermionic_mode_permutations(
+    left::FermionicModePermutation{T},
+    right::FermionicModePermutation{T},
+    domain::AbstractVector{T},
+) where {T<:Integer}
+    images = Dict{T,T}()
+    for idx in domain
+        dst = _mode_image(left, _mode_image(right, idx))
+        dst == idx || (images[idx] = dst)
+    end
+    return FermionicModePermutation(images)
+end
+
 @inline _identity_signed_permutation(::Type{T}) where {T<:Integer} =
     SignedPermutation(Dict{T,Tuple{Int,T}}())
+@inline _identity_fermionic_mode_permutation(::Type{T}) where {T<:Integer} =
+    FermionicModePermutation(Dict{T,T}())
 
 function _symmetry_key(g::SignedPermutation{T}, domain::AbstractVector{T}) where {T<:Integer}
     return Tuple(_signed_image_signature(g, idx) for idx in domain)
 end
 
-function _enumerate_symmetry_group(spec::SymmetrySpec{T}, domain::Vector{T}) where {T<:Integer}
-    isempty(spec.generators) && throw(ArgumentError("`SymmetrySpec` needs at least one generator."))
+function _symmetry_key(g::FermionicModePermutation{T}, domain::AbstractVector{T}) where {T<:Integer}
+    return Tuple(_mode_image(g, idx) for idx in domain)
+end
+
+_validate_finite_action(g::SignedPermutation{T}, domain::AbstractVector{T}) where {T<:Integer} =
+    _validate_signed_permutation(g, domain)
+_validate_finite_action(g::FermionicModePermutation{T}, domain::AbstractVector{T}) where {T<:Integer} =
+    _validate_fermionic_mode_permutation(g, domain)
+
+_compose_finite_actions(left::SignedPermutation{T}, right::SignedPermutation{T}, domain::AbstractVector{T}) where {T<:Integer} =
+    _compose_signed_permutations(left, right, domain)
+_compose_finite_actions(left::FermionicModePermutation{T}, right::FermionicModePermutation{T}, domain::AbstractVector{T}) where {T<:Integer} =
+    _compose_fermionic_mode_permutations(left, right, domain)
+
+_inverse_finite_action(g::SignedPermutation{T}, domain::AbstractVector{T}) where {T<:Integer} = begin
+    images = Dict{T,Tuple{Int,T}}()
+    for idx in domain
+        sign, dst = _signed_image(g, idx)
+        if sign != 1 || idx != dst
+            images[dst] = (sign, idx)
+        end
+    end
+    return SignedPermutation(images)
+end
+
+_inverse_finite_action(g::FermionicModePermutation{T}, domain::AbstractVector{T}) where {T<:Integer} = begin
+    images = Dict{T,T}()
+    for idx in domain
+        dst = _mode_image(g, idx)
+        idx == dst || (images[dst] = idx)
+    end
+    return FermionicModePermutation(images)
+end
+
+_identity_finite_action(::Type{SignedPermutation{T}}) where {T<:Integer} = _identity_signed_permutation(T)
+_identity_finite_action(::Type{FermionicModePermutation{T}}) where {T<:Integer} = _identity_fermionic_mode_permutation(T)
+
+function _enumerate_symmetry_group(spec::SymmetrySpec, domain::Vector{T}) where {T<:Integer}
     isempty(domain) && throw(ArgumentError("Symmetry reduction needs a non-empty active variable domain."))
 
-    for generator in spec.generators
-        _validate_signed_permutation(generator, domain)
+    if !isempty(spec.generators)
+        generators = SignedPermutation{T}[_convert_signed_permutation(T, g) for g in spec.generators]
+        return _enumerate_symmetry_group(generators, domain)
+    elseif !isempty(spec.fermionic_generators)
+        generators = FermionicModePermutation{T}[
+            _convert_fermionic_mode_permutation(T, g) for g in spec.fermionic_generators
+        ]
+        return _enumerate_symmetry_group(generators, domain)
     end
 
-    identity = _identity_signed_permutation(T)
-    seen = Dict{Any,SignedPermutation{T}}(_symmetry_key(identity, domain) => identity)
-    queue = SignedPermutation{T}[identity]
+    throw(ArgumentError("`SymmetrySpec` does not contain any finite symmetry generators."))
+end
+
+function _enumerate_symmetry_group(generators::Vector{G}, domain::Vector{T}) where {G,T<:Integer}
+    isempty(generators) && throw(ArgumentError("Symmetry reduction needs at least one finite generator."))
+
+    for generator in generators
+        _validate_finite_action(generator, domain)
+    end
+
+    identity = _identity_finite_action(G)
+    seen = Dict{Any,G}(_symmetry_key(identity, domain) => identity)
+    queue = G[identity]
 
     while !isempty(queue)
         current = popfirst!(queue)
-        for generator in spec.generators
-            candidate = _compose_signed_permutations(generator, current, domain)
+        for generator in generators
+            candidate = _compose_finite_actions(generator, current, domain)
             key = _symmetry_key(candidate, domain)
             if !haskey(seen, key)
                 seen[key] = candidate
@@ -269,72 +587,62 @@ function _enumerate_symmetry_group(spec::SymmetrySpec{T}, domain::Vector{T}) whe
     return [seen[key] for key in ordered_keys]
 end
 
-function _inverse_signed_permutation(g::SignedPermutation{T}, domain::AbstractVector{T}) where {T<:Integer}
-    images = Dict{T,Tuple{Int,T}}()
-    for idx in domain
-        sign, dst = _signed_image(g, idx)
-        if sign != 1 || idx != dst
-            images[dst] = (sign, idx)
-        end
-    end
-    return SignedPermutation(images)
-end
+@inline _sw_group_value(g::_FiniteSymmetryGroupElement{G,T}) where {G,T<:Integer} = g.group.elements[g.index]
 
-@inline _sw_group_value(g::_SignedPermutationGroupElement{T}) where {T<:Integer} = g.group.elements[g.index]
+Base.eltype(::Type{_FiniteSymmetryGroup{G,T}}) where {G,T<:Integer} = _FiniteSymmetryGroupElement{G,T}
+Base.IteratorSize(::Type{<:_FiniteSymmetryGroup}) = Base.HasLength()
+Base.length(G::_FiniteSymmetryGroup) = length(G.elements)
 
-Base.eltype(::Type{_SignedPermutationGroup{T}}) where {T<:Integer} = _SignedPermutationGroupElement{T}
-Base.IteratorSize(::Type{<:_SignedPermutationGroup}) = Base.HasLength()
-Base.length(G::_SignedPermutationGroup) = length(G.elements)
-
-function Base.iterate(G::_SignedPermutationGroup{T}, state::Int=1) where {T<:Integer}
+function Base.iterate(G::_FiniteSymmetryGroup{GAction,T}, state::Int=1) where {GAction,T<:Integer}
     state > length(G.elements) && return nothing
-    return _SignedPermutationGroupElement{T}(G, state), state + 1
+    return _FiniteSymmetryGroupElement{GAction,T}(G, state), state + 1
 end
 
-Base.one(G::_SignedPermutationGroup{T}) where {T<:Integer} = _SignedPermutationGroupElement{T}(G, 1)
-Base.parent(g::_SignedPermutationGroupElement) = g.group
-Base.copy(g::_SignedPermutationGroupElement) = g
-Base.isone(g::_SignedPermutationGroupElement) = g.index == 1
+Base.one(G::_FiniteSymmetryGroup{GAction,T}) where {GAction,T<:Integer} =
+    _FiniteSymmetryGroupElement{GAction,T}(G, 1)
+Base.parent(g::_FiniteSymmetryGroupElement) = g.group
+Base.copy(g::_FiniteSymmetryGroupElement) = g
+Base.isone(g::_FiniteSymmetryGroupElement) = g.index == 1
 
-function Base.:(==)(a::_SignedPermutationGroupElement{T}, b::_SignedPermutationGroupElement{T}) where {T<:Integer}
+function Base.:(==)(a::_FiniteSymmetryGroupElement{G,T}, b::_FiniteSymmetryGroupElement{G,T}) where {G,T<:Integer}
     return a.group.domain == b.group.domain && _sw_group_value(a) == _sw_group_value(b)
 end
 
-function Base.hash(g::_SignedPermutationGroupElement, h::UInt)
+function Base.hash(g::_FiniteSymmetryGroupElement, h::UInt)
     return hash((g.group.domain, _sw_group_value(g)), h)
 end
 
-function GroupsCore.order(::Type{I}, G::_SignedPermutationGroup) where {I<:Integer}
+function GroupsCore.order(::Type{I}, G::_FiniteSymmetryGroup) where {I<:Integer}
     return convert(I, length(G.elements))
 end
 
-function GroupsCore.order(::Type{I}, g::_SignedPermutationGroupElement) where {I<:Integer}
+function GroupsCore.order(::Type{I}, g::_FiniteSymmetryGroupElement) where {I<:Integer}
     return convert(I, g.group.element_orders[g.index])
 end
 
-function GroupsCore.gens(G::_SignedPermutationGroup{T}) where {T<:Integer}
-    return [_SignedPermutationGroupElement{T}(G, idx) for idx in G.generator_indices]
+function GroupsCore.gens(G::_FiniteSymmetryGroup{GAction,T}) where {GAction,T<:Integer}
+    return [_FiniteSymmetryGroupElement{GAction,T}(G, idx) for idx in G.generator_indices]
 end
 
-function Base.inv(g::_SignedPermutationGroupElement{T}) where {T<:Integer}
-    return _SignedPermutationGroupElement{T}(g.group, g.group.inv_table[g.index])
+function Base.inv(g::_FiniteSymmetryGroupElement{GAction,T}) where {GAction,T<:Integer}
+    return _FiniteSymmetryGroupElement{GAction,T}(g.group, g.group.inv_table[g.index])
 end
 
-function Base.:(*)(a::_SignedPermutationGroupElement{T}, b::_SignedPermutationGroupElement{T}) where {T<:Integer}
+function Base.:(*)(a::_FiniteSymmetryGroupElement{GAction,T}, b::_FiniteSymmetryGroupElement{GAction,T}) where {GAction,T<:Integer}
     a.group.domain == b.group.domain && a.group.elements == b.group.elements || throw(ArgumentError(
-        "Cannot multiply elements from different signed-permutation symmetry groups."
+        "Cannot multiply elements from different finite symmetry groups."
     ))
-    return _SignedPermutationGroupElement{T}(a.group, a.group.mult_table[a.index, b.index])
+    return _FiniteSymmetryGroupElement{GAction,T}(a.group, a.group.mult_table[a.index, b.index])
 end
 
-function _sw_signed_permutation_group(
-    spec::SymmetrySpec{T},
-    group::Vector{SignedPermutation{T}},
+function _sw_finite_action_group(
+    generators::Vector{G},
+    group::Vector{G},
     domain::Vector{T},
-) where {T<:Integer}
-    identity = _identity_signed_permutation(T)
+) where {G,T<:Integer}
+    identity = _identity_finite_action(G)
     identity_key = _symmetry_key(identity, domain)
-    elements = SignedPermutation{T}[identity]
+    elements = G[identity]
     for g in group
         _symmetry_key(g, domain) == identity_key && continue
         push!(elements, g)
@@ -342,7 +650,7 @@ function _sw_signed_permutation_group(
 
     lookup = Dict{Any,Int}(_symmetry_key(g, domain) => i for (i, g) in enumerate(elements))
     generator_indices = Int[]
-    for generator in spec.generators
+    for generator in generators
         idx = get(lookup, _symmetry_key(generator, domain), 0)
         idx == 0 && throw(ArgumentError(
             "Internal symmetry error: failed to locate a generator in the enumerated symmetry group."
@@ -353,7 +661,7 @@ function _sw_signed_permutation_group(
     n = length(elements)
     mult_table = Matrix{Int}(undef, n, n)
     for j in 1:n, i in 1:n
-        product = _compose_signed_permutations(elements[j], elements[i], domain)
+        product = _compose_finite_actions(elements[j], elements[i], domain)
         idx = get(lookup, _symmetry_key(product, domain), 0)
         idx == 0 && throw(ArgumentError(
             "Internal symmetry error: enumerated symmetry group is not closed under multiplication."
@@ -363,7 +671,7 @@ function _sw_signed_permutation_group(
 
     inv_table = Vector{Int}(undef, n)
     for i in 1:n
-        inverse = _inverse_signed_permutation(elements[i], domain)
+        inverse = _inverse_finite_action(elements[i], domain)
         idx = get(lookup, _symmetry_key(inverse, domain), 0)
         idx == 0 && throw(ArgumentError(
             "Internal symmetry error: enumerated symmetry group is missing an inverse element."
@@ -379,13 +687,33 @@ function _sw_signed_permutation_group(
             power = mult_table[power, i]
             order_i += 1
             order_i <= n || throw(ArgumentError(
-                "Internal symmetry error: failed to compute an element order for the signed-permutation group."
+                "Internal symmetry error: failed to compute an element order for the finite symmetry group."
             ))
         end
         element_orders[i] = order_i
     end
 
-    return _SignedPermutationGroup(domain, elements, generator_indices, mult_table, inv_table, element_orders)
+    return _FiniteSymmetryGroup(domain, elements, generator_indices, mult_table, inv_table, element_orders)
+end
+
+function _sw_signed_permutation_group(
+    spec::SymmetrySpec,
+    group::Vector{SignedPermutation{T}},
+    domain::Vector{T},
+) where {T<:Integer}
+    generators = SignedPermutation{T}[_convert_signed_permutation(T, g) for g in spec.generators]
+    return _sw_finite_action_group(generators, group, domain)
+end
+
+function _sw_fermionic_mode_permutation_group(
+    spec::SymmetrySpec,
+    group::Vector{FermionicModePermutation{T}},
+    domain::Vector{T},
+) where {T<:Integer}
+    generators = FermionicModePermutation{T}[
+        _convert_fermionic_mode_permutation(T, g) for g in spec.fermionic_generators
+    ]
+    return _sw_finite_action_group(generators, group, domain)
 end
 
 function SymbolicWedderburn.action(
@@ -397,60 +725,87 @@ function SymbolicWedderburn.action(
     return image, sign
 end
 
+function SymbolicWedderburn.action(
+    ::NCFermionicModePermutationAction{T},
+    g::_FermionicModePermutationGroupElement{Int},
+    mono::NormalMonomial{FermionicAlgebra,T},
+) where {T<:Integer}
+    sign, image = _act_monomial(_sw_group_value(g), mono)
+    return image, sign
+end
+
 function _sw_decompose_half_basis(
     basis::Vector{M},
     group::_SignedPermutationGroup{T},
 ) where {A<:MonoidAlgebra,T<:Integer,M<:NormalMonomial{A,T}}
     action = NCWordSignedPermutationAction{A,T}(A)
-    blocks = SymbolicWedderburn.symmetry_adapted_basis(Float64, group, action, basis)
+    return SymbolicWedderburn.symmetry_adapted_basis(Float64, group, action, basis)
+end
 
-    for block in blocks
-        SymbolicWedderburn.multiplicity(block) == 1 || throw(ArgumentError(
-            "Symmetry reduction MVP currently supports multiplicity-free reductions only. " *
-            "SymbolicWedderburn found a direct summand with multiplicity $(SymbolicWedderburn.multiplicity(block))."
-        ))
-        SymbolicWedderburn.issimple(block) || throw(ArgumentError(
-            "Symmetry reduction MVP currently supports only scalar reduced PSD blocks. " *
-            "SymbolicWedderburn found a non-simple direct summand of size $(size(block, 1))."
-        ))
-        size(block, 1) == 1 || throw(ArgumentError(
-            "Symmetry reduction MVP expected a 1×1 simple direct summand, got size $(size(block, 1))."
-        ))
+function _sw_decompose_half_basis(
+    basis::Vector{NormalMonomial{FermionicAlgebra,T}},
+    group::_FermionicModePermutationGroup{Int},
+) where {T<:Integer}
+    action = NCFermionicModePermutationAction{T}()
+    return SymbolicWedderburn.symmetry_adapted_basis(Float64, group, action, basis)
+end
+
+function _symmetry_support(poly::Polynomial{A,T,C}) where {A<:AlgebraType,T<:Integer,C<:Number}
+    used = Set{T}()
+    for (_, mono) in poly.terms
+        union!(used, _symmetry_support(mono))
     end
+    return used
+end
 
-    return blocks
+function _symmetry_support(mono::NormalMonomial{A,T}) where {A<:AlgebraType,T<:Integer}
+    used = Set{T}()
+    for idx in mono.word
+        push!(used, idx)
+    end
+    return used
 end
 
 function _symmetry_domain(
     pop::PolyOpt{A,T,P},
     corr_sparsity::CorrelativeSparsity{A,T,P,M,Nothing},
     cliques_term_sparsities::Vector{Vector{TermSparsity{M}}},
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number,P<:Polynomial{A,T,C},M<:NormalMonomial{A,T}}
+) where {A<:AlgebraType,T<:Integer,C<:Number,P<:Polynomial{A,T,C},M<:NormalMonomial{A,T}}
     used = Set{T}()
 
     for poly in (pop.objective,)
-        union!(used, variable_indices(poly))
+        union!(used, _symmetry_support(poly))
     end
     for poly in pop.eq_constraints
-        union!(used, variable_indices(poly))
+        union!(used, _symmetry_support(poly))
     end
     for poly in pop.ineq_constraints
-        union!(used, variable_indices(poly))
+        union!(used, _symmetry_support(poly))
     end
     for poly in pop.moment_eq_constraints
-        union!(used, variable_indices(poly))
+        union!(used, _symmetry_support(poly))
     end
 
     for basis in corr_sparsity.clq_mom_mtx_bases
         for mono in basis
-            union!(used, variable_indices(mono))
+            union!(used, _symmetry_support(mono))
         end
     end
     for term_sparsities in cliques_term_sparsities, term_sparsity in term_sparsities, block_basis in term_sparsity.block_bases, mono in block_basis
-        union!(used, variable_indices(mono))
+        union!(used, _symmetry_support(mono))
     end
 
     return sort!(collect(used))
+end
+
+function _mode_symmetry_domain(
+    pop::PolyOpt{A,T,P},
+    corr_sparsity::CorrelativeSparsity{A,T,P,M,Nothing},
+    cliques_term_sparsities::Vector{Vector{TermSparsity{M}}},
+) where {A<:AlgebraType,T<:Integer,C<:Number,P<:Polynomial{A,T,C},M<:NormalMonomial{A,T}}
+    raw_domain = _symmetry_domain(pop, corr_sparsity, cliques_term_sparsities)
+    used = unique!(sort!([Int(abs(idx)) for idx in raw_domain]))
+    return used
 end
 
 function _act_monomial(
@@ -468,6 +823,40 @@ function _act_monomial(
     return sign, image
 end
 
+function _permute_fermionic_word(
+    g::FermionicModePermutation,
+    word::Vector{T},
+) where {T<:Integer}
+    acted = similar(word)
+    for (i, idx) in pairs(word)
+        mode = Int(abs(idx))
+        dst = _mode_image(g, mode)
+        acted[i] = idx < 0 ? -T(dst) : T(dst)
+    end
+    return acted
+end
+
+function _act_monomial(
+    g::FermionicModePermutation,
+    mono::NormalMonomial{FermionicAlgebra,T},
+) where {T<:Integer}
+    terms = _simplified_to_terms(
+        FermionicAlgebra,
+        simplify(FermionicAlgebra, _permute_fermionic_word(g, mono.word)),
+        T,
+    )
+    length(terms) == 1 || throw(ArgumentError(
+        "FermionicModePermutation must preserve monomials after normal ordering; got $(length(terms)) terms for basis element $mono."
+    ))
+
+    coef, image = only(terms)
+    coef == one(coef) && return 1, image
+    coef == -one(coef) && return -1, image
+    throw(ArgumentError(
+        "FermionicModePermutation should induce only a sign on a basis monomial, got coefficient $coef for $mono."
+    ))
+end
+
 function _act_polynomial(
     g::SignedPermutation{T},
     poly::Polynomial{A,T,C},
@@ -481,11 +870,25 @@ function _act_polynomial(
     return Polynomial(acted_terms)
 end
 
+function _act_polynomial(
+    g::FermionicModePermutation,
+    poly::Polynomial{FermionicAlgebra,T,C},
+) where {T<:Integer,C<:Number}
+    acted_terms = Tuple{C,NormalMonomial{FermionicAlgebra,T}}[]
+    for (coef, mono) in poly.terms
+        simplified = simplify(FermionicAlgebra, _permute_fermionic_word(g, mono.word))
+        for (term_coef, image) in _simplified_to_terms(FermionicAlgebra, simplified, T)
+            push!(acted_terms, (coef * term_coef, image))
+        end
+    end
+    return Polynomial(acted_terms)
+end
+
 function _check_polynomial_invariance(
     label::AbstractString,
     poly::Polynomial{A,T,C},
-    group::AbstractVector{<:SignedPermutation{T}},
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number}
+    group::AbstractVector,
+) where {A<:AlgebraType,T<:Integer,C<:Number}
     for g in group
         _act_polynomial(g, poly) == poly || throw(ArgumentError(
             "Symmetry reduction requires $label to be invariant under the supplied symmetry."
@@ -496,8 +899,8 @@ end
 
 function _check_symmetry_invariance(
     pop::PolyOpt{A,T,P},
-    group::AbstractVector{<:SignedPermutation{T}},
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number,P<:Polynomial{A,T,C}}
+    group::AbstractVector,
+) where {A<:AlgebraType,T<:Integer,C<:Number,P<:Polynomial{A,T,C}}
     _check_polynomial_invariance("the objective", pop.objective, group)
 
     for (i, poly) in pairs(pop.eq_constraints)
@@ -516,8 +919,8 @@ end
 function _check_basis_closure(
     label::AbstractString,
     basis::Vector{M},
-    group::AbstractVector{<:SignedPermutation{T}},
-) where {A<:MonoidAlgebra,T<:Integer,M<:NormalMonomial{A,T}}
+    group::AbstractVector,
+) where {A<:AlgebraType,T<:Integer,M<:NormalMonomial{A,T}}
     lookup = Set(basis)
     for g in group, mono in basis
         _, image = _act_monomial(g, mono)
@@ -529,14 +932,14 @@ function _check_basis_closure(
     return nothing
 end
 
-@inline function _symmetric_monomial(mono::NormalMonomial{A,T}) where {A<:MonoidAlgebra,T<:Integer}
+@inline function _symmetric_monomial(mono::NormalMonomial{A,T}) where {A<:AlgebraType,T<:Integer}
     return NormalMonomial{A,T}(symmetric_canon(mono))
 end
 
 function _build_orbit_reducer(
     basis::AbstractVector{<:NormalMonomial{A,T}},
-    group::AbstractVector{<:SignedPermutation{T}},
-) where {A<:MonoidAlgebra,T<:Integer}
+    group::AbstractVector,
+) where {A<:AlgebraType,T<:Integer}
     sym_basis = sorted_unique!(_symmetric_monomial.(collect(basis)))
     sym_basis_set = Set(sym_basis)
 
@@ -587,7 +990,7 @@ end
 function _chop_polynomial(
     poly::Polynomial{A,T,C};
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number}
+) where {A<:AlgebraType,T<:Integer,C<:Number}
     chopped_terms = Tuple{C,NormalMonomial{A,T}}[]
     sizehint!(chopped_terms, length(poly.terms))
     for (coef, mono) in poly.terms
@@ -600,7 +1003,7 @@ function _orbit_reduce_polynomial(
     poly::Polynomial{A,T,C},
     reducer::_OrbitReducer{A,T};
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number}
+) where {A<:AlgebraType,T<:Integer,C<:Number}
     reduced_terms = Tuple{C,NormalMonomial{A,T}}[]
     sizehint!(reduced_terms, length(poly.terms))
 
@@ -621,7 +1024,7 @@ function _orbit_reduce_matrix(
     mat::Matrix{P},
     reducer::_OrbitReducer{A,T};
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number,P<:Polynomial{A,T,C}}
+) where {A<:AlgebraType,T<:Integer,C<:Number,P<:Polynomial{A,T,C}}
     reduced = Matrix{P}(undef, size(mat, 1), size(mat, 2))
     for j in axes(mat, 2), i in axes(mat, 1)
         reduced[i, j] = _orbit_reduce_polynomial(_chop_polynomial(mat[i, j]; atol), reducer; atol)
@@ -632,7 +1035,7 @@ end
 function _poly_is_small(
     poly::Polynomial{A,T,C};
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number}
+) where {A<:AlgebraType,T<:Integer,C<:Number}
     return iszero(_chop_polynomial(poly; atol))
 end
 
@@ -640,7 +1043,7 @@ function _assert_poly_small(
     poly::Polynomial{A,T,C},
     context::AbstractString;
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number}
+) where {A<:AlgebraType,T<:Integer,C<:Number}
     _poly_is_small(poly; atol) || throw(ArgumentError(
         "$context should vanish after symmetry reduction, but got $poly."
     ))
@@ -652,7 +1055,7 @@ function _assert_poly_equal(
     rhs::Polynomial{A,T,C},
     context::AbstractString;
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number}
+) where {A<:AlgebraType,T<:Integer,C<:Number}
     diff = _chop_polynomial(lhs - rhs; atol)
     iszero(diff) || throw(ArgumentError(
         "$context should match after symmetry reduction, but differs by $diff."
@@ -660,11 +1063,35 @@ function _assert_poly_equal(
     return nothing
 end
 
+struct _BasisPartitionBlock{L}
+    indices::Vector{Int}
+    label::L
+    provenance::Symbol
+end
+
+struct _BasisTransformBlock{L,M<:AbstractMatrix}
+    row_basis::M
+    label::L
+    provenance::Symbol
+end
+
+function _chop_polynomial_matrix(mat::Matrix{P}; atol::Float64=_SYMMETRY_ATOL) where {P<:Polynomial}
+    chopped = similar(mat)
+    for j in axes(mat, 2), i in axes(mat, 1)
+        chopped[i, j] = _chop_polynomial(mat[i, j]; atol)
+    end
+    return chopped
+end
+
+@inline _maybe_orbit_reduce_matrix(mat, ::Nothing; atol::Float64=_SYMMETRY_ATOL) = _chop_polynomial_matrix(mat; atol)
+@inline _maybe_orbit_reduce_matrix(mat, reducer::_OrbitReducer; atol::Float64=_SYMMETRY_ATOL) =
+    _orbit_reduce_matrix(mat, reducer; atol)
+
 function _transform_polynomial_block(
     mat::Matrix{P},
-    U_left::AbstractMatrix{<:Real},
-    U_right::AbstractMatrix{<:Real};
-    scale::Real=1,
+    U_left::AbstractMatrix{<:Number},
+    U_right::AbstractMatrix{<:Number};
+    scale::Number=1,
     atol::Float64=_SYMMETRY_ATOL,
 ) where {P<:Polynomial}
     transformed = Matrix{P}(undef, size(U_left, 1), size(U_right, 1))
@@ -672,7 +1099,7 @@ function _transform_polynomial_block(
     for j in axes(transformed, 2), i in axes(transformed, 1)
         acc = zero(P)
         for b in axes(mat, 2), a in axes(mat, 1)
-            coeff = U_left[i, a] * U_right[j, b]
+            coeff = U_left[i, a] * conj(U_right[j, b])
             abs(coeff) <= atol && continue
             acc += coeff * mat[a, b]
         end
@@ -682,17 +1109,57 @@ function _transform_polynomial_block(
     return transformed
 end
 
-function _reduce_to_scalar_blocks_sw(
+function _diagonal_transformed_blocks(
     mat::Matrix{P},
-    blocks,
-    reducer::_OrbitReducer{A,T};
+    row_bases::Vector{<:AbstractMatrix},
+    reducer::Union{Nothing,_OrbitReducer};
+    atol::Float64=_SYMMETRY_ATOL,
+) where {P<:Polynomial}
+    diagonal_blocks = Matrix{P}[]
+    for row_basis in row_bases
+        diagonal = _maybe_orbit_reduce_matrix(
+            _transform_polynomial_block(mat, row_basis, row_basis; atol),
+            reducer;
+            atol,
+        )
+        push!(diagonal_blocks, _chop_polynomial_matrix(diagonal; atol))
+    end
+    return diagonal_blocks
+end
+
+function _append_transformed_offblock_zero_constraints!(
+    constraints::Vector{Tuple{Symbol, Matrix{P}}},
+    mat::Matrix{P},
+    row_bases::Vector{<:AbstractMatrix},
+    reducer::Union{Nothing,_OrbitReducer};
     atol::Float64=_SYMMETRY_ATOL,
     context::AbstractString="constraint matrix",
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number,P<:Polynomial{A,T,C}}
-    row_bases = [Matrix(block) for block in blocks]
-
+) where {P<:Polynomial}
     for i in 1:length(row_bases), j in (i+1):length(row_bases)
-        off_block = _orbit_reduce_matrix(
+        for (left, right) in ((i, j), (j, i))
+            off_block = _maybe_orbit_reduce_matrix(
+                _transform_polynomial_block(mat, row_bases[left], row_bases[right]; atol),
+                reducer;
+                atol,
+            )
+            for col in axes(off_block, 2), row in axes(off_block, 1)
+                poly = _chop_polynomial(off_block[row, col]; atol)
+                iszero(poly) || _append_constraint!(constraints, :Zero, reshape([poly], 1, 1), P)
+            end
+        end
+    end
+    return nothing
+end
+
+function _reduce_transformed_blocks(
+    mat::Matrix{P},
+    row_bases::Vector{<:AbstractMatrix},
+    reducer::Union{Nothing,_OrbitReducer};
+    atol::Float64=_SYMMETRY_ATOL,
+    context::AbstractString="constraint matrix",
+) where {P<:Polynomial}
+    for i in 1:length(row_bases), j in (i+1):length(row_bases)
+        off_block = _maybe_orbit_reduce_matrix(
             _transform_polynomial_block(mat, row_bases[i], row_bases[j]; atol),
             reducer;
             atol,
@@ -705,7 +1172,7 @@ function _reduce_to_scalar_blocks_sw(
             )
         end
 
-        off_block_t = _orbit_reduce_matrix(
+        off_block_t = _maybe_orbit_reduce_matrix(
             _transform_polynomial_block(mat, row_bases[j], row_bases[i]; atol),
             reducer;
             atol,
@@ -719,48 +1186,170 @@ function _reduce_to_scalar_blocks_sw(
         end
     end
 
-    scalar_blocks = Matrix{P}[]
-    for (block_idx, block) in enumerate(blocks)
-        diagonal = _orbit_reduce_matrix(
-            _transform_polynomial_block(
-                mat,
-                row_bases[block_idx],
-                row_bases[block_idx];
-                atol,
-            ),
-            reducer;
-            atol,
-        )
-        size(diagonal) == (1, 1) || throw(ArgumentError(
-            "$context should reduce to a scalar PSD block, got a block of size $(size(diagonal))."
-        ))
-        push!(scalar_blocks, reshape([_chop_polynomial(only(diagonal); atol)], 1, 1))
-    end
-
-    return scalar_blocks
+    return _diagonal_transformed_blocks(mat, row_bases, reducer; atol)
 end
 
 function _reduce_constraint_matrix_symmetric(
     mat::Matrix{P},
     basis::Vector{M},
-    sw_group::_SignedPermutationGroup{T},
-    reducer::_OrbitReducer{A,T};
+    sw_group::_FiniteSymmetryGroup,
+    reducer::Union{Nothing,_OrbitReducer{A,T}};
     atol::Float64=_SYMMETRY_ATOL,
     context::AbstractString="constraint matrix",
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number,P<:Polynomial{A,T,C},M<:NormalMonomial{A,T}}
+) where {A<:AlgebraType,T<:Integer,C<:Number,P<:Polynomial{A,T,C},M<:NormalMonomial{A,T}}
     if length(basis) == 1
-        reduced = _orbit_reduce_matrix(mat, reducer; atol)
-        return [reshape([_chop_polynomial(only(reduced); atol)], 1, 1)]
+        return [_maybe_orbit_reduce_matrix(mat, reducer; atol)]
     end
 
     blocks = _sw_decompose_half_basis(basis, sw_group)
-    return _reduce_to_scalar_blocks_sw(mat, blocks, reducer; atol, context)
+    row_bases = [Matrix(block) for block in blocks]
+    return _reduce_transformed_blocks(mat, row_bases, reducer; atol, context)
+end
+
+function _validate_fermionic_sector_spec(sector::FermionicSectorSpec)
+    (sector.split_parity || sector.split_number || sector.split_spin || sector.split_irrep) ||
+        throw(ArgumentError("`FermionicSectorSpec` must enable at least one sector split."))
+    return nothing
+end
+
+function _neutral_fermionic_sector_label(sector::FermionicSectorSpec)
+    return FermionicSectorLabel(
+        sector.split_parity ? 0 : nothing,
+        sector.split_number ? 0 : nothing,
+        sector.split_spin ? 0 : nothing,
+        sector.split_irrep ? _fermionic_irrep_identity(sector) : nothing,
+    )
+end
+
+function _fermionic_mode_spin2(sector::FermionicSectorSpec, mode::Int)
+    haskey(sector.mode_layout.spin2_of, mode) || throw(ArgumentError(
+        "Fermionic spin-sector splitting needs `spin2_of[$mode]` in the supplied `FermionicModeLayout`."
+    ))
+    return sector.mode_layout.spin2_of[mode]
+end
+
+function _fermionic_sector_label(
+    mono::NormalMonomial{FermionicAlgebra,T},
+    sector::FermionicSectorSpec,
+) where {T<:Integer}
+    parity = sector.split_parity ? mod(length(mono.word), 2) : nothing
+    number = nothing
+    spin2 = sector.split_spin ? 0 : nothing
+    irrep = sector.split_irrep ? _fermionic_irrep_identity(sector) : nothing
+
+    if sector.split_number
+        n_creators = count(<(zero(T)), mono.word)
+        number = n_creators - (length(mono.word) - n_creators)
+    end
+
+    for idx in mono.word
+        mode = Int(abs(idx))
+
+        if sector.split_spin
+            contribution = _fermionic_mode_spin2(sector, mode)
+            spin2 += idx < 0 ? contribution : -contribution
+        end
+
+        if sector.split_irrep
+            irrep = _fermionic_irrep_multiply(
+                sector,
+                irrep,
+                idx < 0 ? _fermionic_mode_irrep(sector, mode) :
+                    _fermionic_irrep_dual(sector, _fermionic_mode_irrep(sector, mode)),
+            )
+        end
+    end
+
+    return FermionicSectorLabel(parity, number, spin2, irrep)
+end
+
+function _fermionic_polynomial_sector_label(
+    poly::Polynomial{FermionicAlgebra,T,C},
+    sector::FermionicSectorSpec,
+    context::AbstractString,
+) where {T<:Integer,C<:Number}
+    isempty(poly.terms) && return _neutral_fermionic_sector_label(sector)
+
+    label = nothing
+    for (_, mono) in poly.terms
+        mono_label = _fermionic_sector_label(mono, sector)
+        if isnothing(label)
+            label = mono_label
+        elseif mono_label != label
+            throw(ArgumentError(
+                "Fermionic sector splitting currently requires each $context to be homogeneous in the enabled sector labels. Mixed labels found in $poly."
+            ))
+        end
+    end
+
+    return something(label, _neutral_fermionic_sector_label(sector))
+end
+
+function _sector_partition_blocks(
+    basis::AbstractVector{<:NormalMonomial{FermionicAlgebra,T}},
+    sector::FermionicSectorSpec,
+) where {T<:Integer}
+    labels = FermionicSectorLabel[_fermionic_sector_label(mono, sector) for mono in basis]
+    by_label = Dict{FermionicSectorLabel,Vector{Int}}()
+    order = FermionicSectorLabel[]
+
+    for (idx, label) in enumerate(labels)
+        if !haskey(by_label, label)
+            by_label[label] = Int[]
+            push!(order, label)
+        end
+        push!(by_label[label], idx)
+    end
+
+    blocks = [_BasisPartitionBlock(by_label[label], label, :sector_split) for label in order]
+    return blocks, labels
+end
+
+function _check_sectorwise_basis_closure(
+    label::AbstractString,
+    basis::AbstractVector{<:NormalMonomial{FermionicAlgebra,T}},
+    group::AbstractVector,
+    sector::FermionicSectorSpec,
+) where {T<:Integer}
+    sector_blocks, _ = _sector_partition_blocks(basis, sector)
+    for block in sector_blocks
+        _check_basis_closure("$label sector $(block.label)", basis[block.indices], group)
+    end
+    return nothing
+end
+
+function _append_sector_zero_constraints!(
+    constraints::Vector{Tuple{Symbol, Matrix{MP}}},
+    mat::Matrix{MP},
+    sector_blocks::Vector{<:_BasisPartitionBlock},
+    reducer::Union{Nothing,_OrbitReducer};
+    atol::Float64=_SYMMETRY_ATOL,
+    context::AbstractString="constraint matrix",
+) where {MP<:Polynomial}
+    for i in 1:length(sector_blocks), j in (i+1):length(sector_blocks)
+        rows = sector_blocks[i].indices
+        cols = sector_blocks[j].indices
+
+        for row in rows, col in cols
+            poly = reducer === nothing ? _chop_polynomial(mat[row, col]; atol) :
+                _orbit_reduce_polynomial(_chop_polynomial(mat[row, col]; atol), reducer; atol)
+            iszero(poly) || _append_constraint!(constraints, :Zero, reshape([poly], 1, 1), MP)
+        end
+
+        for row in cols, col in rows
+            poly = reducer === nothing ? _chop_polynomial(mat[row, col]; atol) :
+                _orbit_reduce_polynomial(_chop_polynomial(mat[row, col]; atol), reducer; atol)
+            iszero(poly) || _append_constraint!(constraints, :Zero, reshape([poly], 1, 1), MP)
+        end
+    end
+
+    return nothing
 end
 
 function _collect_reduced_basis(
     objective::Polynomial{A,T,C},
     constraints::Vector{Tuple{Symbol, Matrix{Polynomial{A,T,C}}}},
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number}
+) where {A<:AlgebraType,T<:Integer,C<:Number}
     basis = NormalMonomial{A,T}[]
     append!(basis, monomials(objective))
     for (_, mat) in constraints, poly in mat
@@ -774,10 +1363,10 @@ function _add_moment_eq_constraints_symmetric!(
     pop::PolyOpt{A,T,PP},
     moment_eq_row_bases::Vector{M},
     moment_eq_row_basis_degrees::Vector{Int},
-    reducer::_OrbitReducer{A,T},
+    reducer::Union{Nothing,_OrbitReducer{A,T}},
     ::Type{MP};
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,CMP<:Number,CPP<:Number,M<:NormalMonomial{A,T},MP<:Polynomial{A,T,CMP},PP<:Polynomial{A,T,CPP}}
+) where {A<:AlgebraType,T<:Integer,CMP<:Number,CPP<:Number,M<:NormalMonomial{A,T},MP<:Polynomial{A,T,CMP},PP<:Polynomial{A,T,CPP}}
     isempty(pop.moment_eq_constraints) && return nothing
 
     one_mono = one(NormalMonomial{A,T})
@@ -792,9 +1381,10 @@ function _add_moment_eq_constraints_symmetric!(
                 for (coef, mono) in g.terms;
                 init=zero(MP)
             )
-            poly = _orbit_reduce_polynomial(_chop_polynomial(poly; atol), reducer; atol)
+            poly = reducer === nothing ? _chop_polynomial(poly; atol) :
+                _orbit_reduce_polynomial(_chop_polynomial(poly; atol), reducer; atol)
             iszero(poly) && continue
-            push!(constraints, (:Zero, reshape([poly], 1, 1)))
+            _append_constraint!(constraints, :Zero, reshape([poly], 1, 1), MP)
         end
     end
 
@@ -805,7 +1395,8 @@ end
 """
     moment_relax_symmetric(pop, corr_sparsity, cliques_term_sparsities, symmetry)
 
-Construct a symmetry-reduced symbolic moment problem for the dense monoid MVP.
+Construct a symmetry-reduced symbolic moment problem for dense ordinary polynomial
+relaxations. The output contract is still the usual `MomentProblem`.
 """
 function moment_relax_symmetric(
     pop::PolyOpt{A,T,P},
@@ -813,25 +1404,19 @@ function moment_relax_symmetric(
     cliques_term_sparsities::Vector{Vector{TermSparsity{M}}},
     symmetry::SymmetrySpec;
     atol::Float64=_SYMMETRY_ATOL,
-) where {A<:MonoidAlgebra,T<:Integer,C<:Number,P<:Polynomial{A,T,C},M<:NormalMonomial{A,T}}
-    spec = _convert_symmetry_spec(T, symmetry)
-    domain = _symmetry_domain(pop, corr_sparsity, cliques_term_sparsities)
-    group = _enumerate_symmetry_group(spec, domain)
-    sw_group = _sw_signed_permutation_group(spec, group, domain)
-
-    spec.check_invariance && _check_symmetry_invariance(pop, group)
-
-    for (clique_idx, basis) in enumerate(corr_sparsity.clq_mom_mtx_bases)
-        _check_basis_closure("moment basis of clique $clique_idx", basis, group)
+) where {A<:AlgebraType,T<:Integer,C<:Number,P<:Polynomial{A,T,C},M<:NormalMonomial{A,T}}
+    sector = symmetry.sector
+    spin_adaptation = symmetry.spin_adaptation
+    if !isnothing(sector)
+        A === FermionicAlgebra || throw(ArgumentError(
+            "Fermionic sector splitting is only supported for `FermionicAlgebra`; got `$(nameof(A))`."
+        ))
+        _validate_fermionic_sector_spec(sector)
     end
-    for (clique_idx, term_sparsities) in enumerate(cliques_term_sparsities)
-        for (poly_idx, term_sparsity) in enumerate(term_sparsities)
-            _check_basis_closure(
-                "constraint block basis $(poly_idx) of clique $clique_idx",
-                only(term_sparsity.block_bases),
-                group,
-            )
-        end
+    if !isnothing(spin_adaptation)
+        A === FermionicAlgebra || throw(ArgumentError(
+            "Fermionic spin adaptation is only supported for `FermionicAlgebra`; got `$(nameof(A))`."
+        ))
     end
 
     moment_matrix_basis = _moment_matrix_basis(cliques_term_sparsities)
@@ -839,16 +1424,90 @@ function moment_relax_symmetric(
         _polynomial_total_basis(pop, corr_sparsity, cliques_term_sparsities)
     _validate_polynomial_relaxation_support(pop, total_basis; source="Constructed relaxation basis")
 
-    reducer = _build_orbit_reducer(total_basis, group)
+    active_modes = if A === FermionicAlgebra && (!isnothing(sector) || !isnothing(spin_adaptation) || !isempty(symmetry.fermionic_generators))
+        _mode_symmetry_domain(pop, corr_sparsity, cliques_term_sparsities)
+    else
+        Int[]
+    end
+    !isnothing(sector) && _validate_active_fermionic_sector_metadata(sector, active_modes)
+    !isnothing(spin_adaptation) && _validate_fermionic_spin_adaptation_spec(
+        symmetry,
+        active_modes,
+    )
+
+    group = nothing
+    sw_group = nothing
+    reducer = nothing
+    group_order = 1
+
+    if !isempty(symmetry.generators)
+        spec = _convert_symmetry_spec(T, symmetry)
+        domain = _symmetry_domain(pop, corr_sparsity, cliques_term_sparsities)
+        group = _enumerate_symmetry_group(spec, domain)
+        sw_group = _sw_signed_permutation_group(spec, group, domain)
+    elseif !isempty(symmetry.fermionic_generators)
+        domain = _mode_symmetry_domain(pop, corr_sparsity, cliques_term_sparsities)
+        group = _enumerate_symmetry_group(symmetry, domain)
+        sw_group = _sw_fermionic_mode_permutation_group(symmetry, group, domain)
+    end
+
+    if !isnothing(group)
+        symmetry.check_invariance && _check_symmetry_invariance(pop, group)
+
+        for (clique_idx, basis) in enumerate(corr_sparsity.clq_mom_mtx_bases)
+            if !isnothing(sector) && A === FermionicAlgebra
+                _check_sectorwise_basis_closure("moment basis of clique $clique_idx", basis, group, sector)
+            else
+                _check_basis_closure("moment basis of clique $clique_idx", basis, group)
+            end
+        end
+
+        for (clique_idx, term_sparsities) in enumerate(cliques_term_sparsities)
+            for (poly_idx, term_sparsity) in enumerate(term_sparsities)
+                for (block_idx, basis) in enumerate(term_sparsity.block_bases)
+                    if !isnothing(sector) && A === FermionicAlgebra
+                        _check_sectorwise_basis_closure(
+                            "constraint block basis $(poly_idx).$(block_idx) of clique $clique_idx",
+                            basis,
+                            group,
+                            sector,
+                        )
+                    else
+                        _check_basis_closure(
+                            "constraint block basis $(poly_idx).$(block_idx) of clique $clique_idx",
+                            basis,
+                            group,
+                        )
+                    end
+                end
+            end
+        end
+
+        reducer = _build_orbit_reducer(total_basis, group)
+        group_order = length(group)
+    end
 
     psd_cone = _is_complex_problem(A) ? :HPSD : :PSD
     MP_C = _moment_problem_coeff_type(A, C)
     MP_P = Polynomial{A,T,MP_C}
-    objective_mp = _orbit_reduce_polynomial(convert(MP_P, pop.objective), reducer; atol)
+
+    objective_mp = convert(MP_P, pop.objective)
+    objective_mp = reducer === nothing ? _chop_polynomial(objective_mp; atol) :
+        _orbit_reduce_polynomial(objective_mp, reducer; atol)
+
+    if !isnothing(sector)
+        neutral_label = _neutral_fermionic_sector_label(sector)
+        objective_label = _fermionic_polynomial_sector_label(objective_mp, sector, "objective")
+        objective_label == neutral_label || throw(ArgumentError(
+            "Fermionic sector splitting currently supports only sector-neutral objectives. Got label $objective_label for the objective."
+        ))
+    end
 
     constraints = Tuple{Symbol, Matrix{MP_P}}[]
     reduced_moment_terms = NormalMonomial{A,T}[]
     reduced_moment_block_sizes = Int[]
+    moment_block_labels = Any[]
+    moment_block_provenance = Symbol[]
 
     for (clique_idx, (term_sparsities, cons_idx)) in enumerate(zip(cliques_term_sparsities, corr_sparsity.clq_cons))
         polys = [one(pop.objective); corr_sparsity.cons[cons_idx]...]
@@ -856,22 +1515,92 @@ function moment_relax_symmetric(
         for (poly_idx, (term_sparsity, poly)) in enumerate(zip(term_sparsities, polys))
             for (block_idx, basis) in enumerate(term_sparsity.block_bases)
                 cone = poly in pop.eq_constraints ? :Zero : psd_cone
-                _, mat = _build_constraint_matrix(poly, basis, cone)
-                scalar_blocks = _reduce_constraint_matrix_symmetric(
-                    mat,
-                    basis,
-                    sw_group,
-                    reducer;
-                    atol,
-                    context="clique $clique_idx block $block_idx for polynomial $poly_idx",
-                )
+                _, raw_mat = _build_constraint_matrix(poly, basis, cone)
+                mat = _convert_polynomial_matrix(MP_P, raw_mat)
 
-                for scalar_block in scalar_blocks
-                    _append_constraint!(constraints, cone, scalar_block, MP_P)
-                    poly_idx == 1 && append!(reduced_moment_terms, monomials(only(scalar_block)))
+                diagonal_blocks = Matrix{MP_P}[]
+                diagonal_labels = Any[]
+                diagonal_provenance = Symbol[]
+                context = "clique $clique_idx block $block_idx for polynomial $poly_idx"
+
+                if !isnothing(sector)
+                    neutral_label = _neutral_fermionic_sector_label(sector)
+                    poly_label = _fermionic_polynomial_sector_label(convert(MP_P, poly), sector, context)
+                    poly_label == neutral_label || throw(ArgumentError(
+                        "Fermionic sector splitting currently supports only sector-neutral multipliers. Got label $poly_label for $context."
+                    ))
+
+                    sector_blocks, _ = _sector_partition_blocks(basis, sector)
+                    _append_sector_zero_constraints!(constraints, mat, sector_blocks, reducer; atol, context)
+
+                    for sector_block in sector_blocks
+                        sector_basis = basis[sector_block.indices]
+                        sector_mat = mat[sector_block.indices, sector_block.indices]
+                        transform_blocks = _fermionic_sector_transform_blocks(
+                            sector_basis,
+                            sector_block.label,
+                            sw_group,
+                            spin_adaptation,
+                            active_modes;
+                            atol,
+                            context="$context sector $(sector_block.label)",
+                        )
+                        row_bases = [block.row_basis for block in transform_blocks]
+                        if isnothing(spin_adaptation)
+                            sector_diag_blocks = _reduce_transformed_blocks(
+                                sector_mat,
+                                row_bases,
+                                reducer;
+                                atol,
+                                context="$context sector $(sector_block.label)",
+                            )
+                        else
+                            _append_transformed_offblock_zero_constraints!(
+                                constraints,
+                                sector_mat,
+                                row_bases,
+                                reducer;
+                                atol,
+                                context="$context sector $(sector_block.label)",
+                            )
+                            sector_diag_blocks = _diagonal_transformed_blocks(
+                                sector_mat,
+                                row_bases,
+                                reducer;
+                                atol,
+                            )
+                        end
+
+                        append!(diagonal_blocks, sector_diag_blocks)
+                        append!(diagonal_labels, [block.label for block in transform_blocks])
+                        append!(diagonal_provenance, [block.provenance for block in transform_blocks])
+                    end
+                else
+                    diagonal_blocks = isnothing(sw_group) ?
+                        [_maybe_orbit_reduce_matrix(mat, reducer; atol)] :
+                        _reduce_constraint_matrix_symmetric(
+                            mat,
+                            basis,
+                            sw_group,
+                            reducer;
+                            atol,
+                            context=context,
+                        )
+                    diagonal_labels = fill(nothing, length(diagonal_blocks))
+                    diagonal_provenance = fill(isnothing(sw_group) ? :identity : :wedderburn, length(diagonal_blocks))
                 end
 
-                poly_idx == 1 && append!(reduced_moment_block_sizes, fill(1, length(scalar_blocks)))
+                for (diag_block, label, provenance) in zip(diagonal_blocks, diagonal_labels, diagonal_provenance)
+                    _append_constraint!(constraints, cone, diag_block, MP_P)
+                    if poly_idx == 1
+                        for poly_entry in diag_block
+                            append!(reduced_moment_terms, monomials(poly_entry))
+                        end
+                        push!(reduced_moment_block_sizes, size(diag_block, 1))
+                        push!(moment_block_labels, label)
+                        push!(moment_block_provenance, provenance)
+                    end
+                end
             end
         end
     end
@@ -879,8 +1608,29 @@ function moment_relax_symmetric(
     for global_con in corr_sparsity.global_cons
         poly = corr_sparsity.cons[global_con]
         cone = poly in pop.eq_constraints ? :Zero : psd_cone
-        reduced_poly = _orbit_reduce_polynomial(convert(MP_P, poly), reducer; atol)
+        reduced_poly = convert(MP_P, poly)
+        reduced_poly = reducer === nothing ? _chop_polynomial(reduced_poly; atol) :
+            _orbit_reduce_polynomial(reduced_poly, reducer; atol)
+
+        if !isnothing(sector)
+            neutral_label = _neutral_fermionic_sector_label(sector)
+            poly_label = _fermionic_polynomial_sector_label(reduced_poly, sector, "global constraint $global_con")
+            poly_label == neutral_label || throw(ArgumentError(
+                "Fermionic sector splitting currently supports only sector-neutral global constraints. Got label $poly_label for global constraint $global_con."
+            ))
+        end
+
         _append_constraint!(constraints, cone, reshape([reduced_poly], 1, 1), MP_P)
+    end
+
+    if !isnothing(sector)
+        neutral_label = _neutral_fermionic_sector_label(sector)
+        for (i, g) in pairs(pop.moment_eq_constraints)
+            label = _fermionic_polynomial_sector_label(convert(MP_P, g), sector, "moment equality constraint $i")
+            label == neutral_label || throw(ArgumentError(
+                "Fermionic sector splitting currently supports only sector-neutral moment equality constraints. Got label $label for moment equality constraint $i."
+            ))
+        end
     end
 
     _add_moment_eq_constraints_symmetric!(
@@ -903,13 +1653,16 @@ function moment_relax_symmetric(
         reduced_total_basis,
         n_unique_moment_matrix_elements,
     )
+    _add_parity_constraints!(mp)
 
     report = SymmetryReport(
-        length(group),
+        group_order,
         count(mono -> !isone(mono), reduced_moment_basis),
         reduced_moment_block_sizes,
         length(only(corr_sparsity.clq_mom_mtx_bases)),
         length(moment_matrix_basis),
+        moment_block_labels,
+        moment_block_provenance,
     )
 
     return mp, report

--- a/test/data/expectations/fermionic_symmetry.toml
+++ b/test/data/expectations/fermionic_symmetry.toml
@@ -1,0 +1,42 @@
+schema_version = 1
+
+[[cases]]
+id = "two_orbital_pair_sector_spin_blocks"
+notes = "Structural SU(2) regression on the two-spatial-orbital, two-electron, M_S = 0 pair-creation sector over four spin orbitals (1↑, 1↓, 2↑, 2↓). The Casimir-adapted block sizes must be [3, 1] for singlet/triplet splitting. `objective` is a dummy placeholder because the shared oracle loader requires it."
+
+    [cases.expected]
+    objective = 0.0
+    sides = [3, 1]
+
+[[cases]]
+id = "h2_sto3g_sector_labels"
+notes = "Structural label-only H₂/STO-3G molecular-orbital regression in the (σ_g, σ_u) basis. Diagonal densities a†_{gσ}a_{gσ} and a†_{uσ}a_{uσ} must be irrep-neutral (`:Ag`), while transitions a†_{gσ}a_{uσ} and a†_{uσ}a_{gσ} must carry the odd irrep (`:B1u`). `objective` is a dummy placeholder because the shared oracle loader requires it."
+
+    [cases.expected]
+    objective = 0.0
+    diagonal_irrep = "Ag"
+    transition_irrep = "B1u"
+
+[[cases]]
+id = "h2_sto3g_n2_spin_adapted"
+notes = "H₂/STO-3G in molecular-orbital form over four spin orbitals (σ_g↑, σ_g↓, σ_u↑, σ_u↓), with electronic-only one- and two-electron integrals reviewed offline and N = 2 enforced by `moment_eq_constraints`. `objective` is the exact electronic N = 2 ground-state energy from finite-dimensional diagonalization of the same polynomial (no nuclear-repulsion constant added). `sides` records the reviewed symmetry-adapted PSD block sizes from a local COSMO order-2 run."
+
+    [cases.expected]
+    objective = -1.8510462258674936
+    sides = [1, 2, 1, 1, 1, 2, 2, 2, 2, 3, 2, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+[[cases]]
+id = "be_1s_2s_spin_blocks"
+notes = "Structural-only Be worked example from the fermionic symmetry note: two spatial orbitals (1s, 2s), doubled by spin. The spin-zero one-body density sector splits into singlet/triplet SU(2) blocks of sizes [2, 2]. `objective` is a dummy placeholder because the shared oracle loader requires it."
+
+    [cases.expected]
+    objective = 0.0
+    sides = [2, 2]
+
+[[cases]]
+id = "be_1s_2s_one_body_n2_order1"
+notes = "Be STO-6G-derived 1s/2s one-body slice with two active electrons and canonical N=2 enforced by `moment_eq_constraints`. One-electron integrals come from Nakata/Braams public `Be.1S.STO6G.eri`; the exact reference objective is 2 * λ_min(h), where h is the 2x2 spatial one-electron matrix. `sides` records the reviewed symmetry-adapted PSD block sizes from a local COSMO run."
+
+    [cases.expected]
+    objective = -15.90163070552046
+    sides = [5, 4]

--- a/test/data/expectations/hubbard.toml
+++ b/test/data/expectations/hubbard.toml
@@ -19,6 +19,23 @@ notes = "Spinful 4-site 1D Hubbard ring with doubled fermionic modes. This is th
     nuniq = 2517
 
 [[cases]]
+id = "open_n2_u4_dimer_order2"
+notes = "Open two-site spinful Hubbard dimer with doubled fermionic modes, t = 1 and U = 4, canonical total particle number N = 2 enforced by `moment_eq_constraints`. `objective` is the reviewed dense order-2 COSMO value. The exact half-filled dimer energy is U/2 - sqrt((U/2)^2 + 4 t^2) = -0.8284271247461903."
+
+    [cases.expected]
+    objective = -0.8284271069571899
+    sides = [37]
+    nuniq = 163
+
+[[cases]]
+id = "open_n2_u4_dimer_order2_spin_symmetry"
+notes = "Open two-site spinful Hubbard dimer with N = 2, sector splitting by parity/number/S_z, finite site-swap symmetry, and Casimir-based S^2 spin adaptation. `objective` is the reviewed symmetry-adapted order-2 COSMO value and `sides` records the symmetry-reduced PSD block sizes from the same run."
+
+    [cases.expected]
+    objective = -0.828427159549658
+    sides = [1, 2, 1, 1, 1, 2, 2, 3, 2, 2, 2, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+[[cases]]
 id = "periodic_n4_u4_order2_canonical"
 notes = "Spinful 4-site 1D Hubbard ring, canonical half-filling (N_up=2, N_dn=2). Uses moment_eq_constraints for one-sided localizing of particle-number constraints. Exact half-filled sector GS is -2.102748483462074."
 

--- a/test/problems/condensed_matter/hubbard.jl
+++ b/test/problems/condensed_matter/hubbard.jl
@@ -9,10 +9,12 @@
 # lower bound. The canonical test uses `moment_eq_constraints` to fix
 # (N_up, N_dn) = (2, 2) via one-sided localizing constraints g|ψ⟩ = 0.
 #
-# The two-site periodic ring is still useful because its unconstrained ground
-# state already sits in the half-filled sector. The four-site ring exercises the
-# actual N=4, t=1, U=4 model both as a grand-canonical Hamiltonian (full-Fock
-# lower bound) and as a canonical half-filling problem.
+# The open two-site dimer is the smallest exact symmetry benchmark here: it has
+# one honest bond, a closed-form N=2 singlet energy, and clean site-swap / S_z /
+# S^2 structure. The two-site periodic ring is still useful because its
+# unconstrained ground state already sits in the half-filled sector. The four-site
+# ring exercises the actual N=4, t=1, U=4 model both as a grand-canonical
+# Hamiltonian (full-Fock lower bound) and as a canonical half-filling problem.
 
 using Test, NCTSSoS, JuMP, LinearAlgebra
 import NCTSSoS: degree
@@ -93,6 +95,51 @@ function _hubbard_problem(nsites::Int; t::Real, U::Real, periodic::Bool)
 
     return registry, (c_up, c_up_dag), (c_dn, c_dn_dag), hopping + interaction
 end
+
+function _hubbard_mode_layout(c_up, c_dn)
+    nsites = length(c_up)
+    up_modes = Int[Int(op.word[1]) for op in c_up]
+    dn_modes = Int[Int(op.word[1]) for op in c_dn]
+
+    return FermionicModeLayout(
+        Dict(vcat(
+            [up_modes[i] => i for i in 1:nsites],
+            [dn_modes[i] => i for i in 1:nsites],
+        ));
+        spin2_of=Dict(vcat(
+            [up_modes[i] => 1 for i in 1:nsites],
+            [dn_modes[i] => -1 for i in 1:nsites],
+        )),
+    )
+end
+
+function _hubbard_site_swap_generator(c_up, c_dn)
+    nsites = length(c_up)
+    up_modes = Int[Int(op.word[1]) for op in c_up]
+    dn_modes = Int[Int(op.word[1]) for op in c_dn]
+
+    images = Dict{Int,Int}()
+    for i in 1:nsites
+        images[up_modes[i]] = up_modes[mod1(i + 1, nsites)]
+        images[dn_modes[i]] = dn_modes[mod1(i + 1, nsites)]
+    end
+
+    return FermionicModePermutation(images)
+end
+
+function _hubbard_site_swap_symmetry(c_up, c_dn)
+    return SymmetrySpec(
+        fermionic_generators=[_hubbard_site_swap_generator(c_up, c_dn)],
+        sector=FermionicSectorSpec(
+            mode_layout=_hubbard_mode_layout(c_up, c_dn),
+            split_parity=true,
+            split_number=true,
+            split_spin=true,
+        ),
+    )
+end
+
+_hubbard_open_dimer_ground_state_energy(t::Real, U::Real) = U / 2 - sqrt((U / 2)^2 + 4 * t^2)
 
 function _sector_indices(nsites::Int; nup::Int, ndn::Int)
     nmodes = 2 * nsites
@@ -192,5 +239,121 @@ end
         @test result.objective > -3.5  # must not drop to full-Fock GS
         @test reduce(vcat, result.moment_matrix_sizes) == oracle.sides
         @test result.n_unique_moment_matrix_elements == oracle.nuniq
+    end
+
+    @testset "Open two-site dimer (canonical N=2 with sector, swap, and spin adaptation)" begin
+        N = 2
+        t = 1.0
+        U = 4.0
+        dense_oracle = expectations_oracle(HUBBARD_EXPECTATIONS_PATH, "open_n2_u4_dimer_order2")
+        adapted_oracle = expectations_oracle(HUBBARD_EXPECTATIONS_PATH, "open_n2_u4_dimer_order2_spin_symmetry")
+
+        registry, (c_up, c_up_dag), (c_dn, c_dn_dag), ham = _hubbard_problem(N; t, U, periodic=false)
+        exact_hamiltonian = _hubbard_fermion_poly_matrix(ham, 2 * N)
+        exact_e0 = _sector_ground_state_energy(exact_hamiltonian, N; nup=1, ndn=1)
+        analytic_e0 = _hubbard_open_dimer_ground_state_energy(t, U)
+        n_total = 1.0 * sum(c_up_dag[i] * c_up[i] + c_dn_dag[i] * c_dn[i] for i in 1:N)
+        pop = polyopt(ham, registry; moment_eq_constraints=[n_total - 2.0 * one(ham)])
+
+        dense = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                order=2,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+            ),
+        )
+
+        mode_layout = _hubbard_mode_layout(c_up, c_dn)
+        sector = FermionicSectorSpec(
+            mode_layout=mode_layout,
+            split_parity=true,
+            split_number=true,
+            split_spin=true,
+        )
+        spin = FermionicSpinAdaptationSpec(mode_layout=mode_layout)
+        sector_only = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                order=2,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=SymmetrySpec(sector=sector),
+            ),
+        )
+        adapted = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                order=2,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=SymmetrySpec(
+                    fermionic_generators=[_hubbard_site_swap_generator(c_up, c_dn)],
+                    sector=sector,
+                    spin_adaptation=spin,
+                ),
+            ),
+        )
+
+        @test exact_e0 ≈ analytic_e0 atol = 1e-12
+        @test dense.objective ≈ dense_oracle.opt atol = 5e-6
+        @test dense.objective ≈ exact_e0 atol = 5e-6
+        @test dense.n_unique_moment_matrix_elements == dense_oracle.nuniq
+        @test reduce(vcat, dense.moment_matrix_sizes) == dense_oracle.sides
+
+        @test sector_only.objective ≈ dense.objective atol = 5e-6
+        @test sector_only.objective ≈ exact_e0 atol = 5e-6
+        @test !isnothing(sector_only.symmetry)
+
+        @test adapted.objective ≈ adapted_oracle.opt atol = 5e-6
+        @test adapted.objective ≈ dense.objective atol = 5e-6
+        @test adapted.objective ≈ exact_e0 atol = 5e-6
+        @test !isnothing(adapted.symmetry)
+        @test adapted.symmetry.group_order == 2
+        @test adapted.symmetry.psd_block_sizes == adapted_oracle.sides
+        @test maximum(adapted.symmetry.psd_block_sizes) < maximum(reduce(vcat, dense.moment_matrix_sizes))
+        @test maximum(adapted.symmetry.psd_block_sizes) < maximum(sector_only.symmetry.psd_block_sizes)
+        spin_labels = Set(label.total_spin2 for label in adapted.symmetry.block_labels if label isa FermionicSpinBlockLabel)
+        @test 0 in spin_labels
+        @test 2 in spin_labels
+    end
+
+    @testset "Periodic two-site ring (canonical half-filling with symmetry sectors)" begin
+        N = 2
+        t = 1.0
+        U = 4.0
+
+        registry, (c_up, c_up_dag), (c_dn, c_dn_dag), ham = _hubbard_problem(N; t, U, periodic=true)
+        n_up_total = 1.0 * sum(c_up_dag[i] * c_up[i] for i in 1:N)
+        n_dn_total = 1.0 * sum(c_dn_dag[i] * c_dn[i] for i in 1:N)
+        pop = polyopt(
+            ham,
+            registry;
+            moment_eq_constraints=[
+                n_up_total - 1.0 * one(ham),
+                n_dn_total - 1.0 * one(ham),
+            ],
+        )
+
+        dense = cs_nctssos(pop, SolverConfig(optimizer=SOLVER, order=2))
+        symmetric = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                order=2,
+                symmetry=_hubbard_site_swap_symmetry(c_up, c_dn),
+            ),
+        )
+
+        @test symmetric.objective ≈ dense.objective atol = 1e-5
+        @test !isnothing(symmetric.symmetry)
+        @test symmetric.symmetry.group_order == 2
+        @test maximum(symmetric.symmetry.psd_block_sizes) < maximum(reduce(vcat, dense.moment_matrix_sizes))
+        @test any(label -> label isa FermionicSectorLabel && label.number == 0 && label.spin2 == 0, symmetric.symmetry.block_labels)
+        @test any(label -> label isa FermionicSectorLabel && label.number == 1 && label.spin2 == 1, symmetric.symmetry.block_labels)
+        @test any(label -> label isa FermionicSectorLabel && label.number == 1 && label.spin2 == -1, symmetric.symmetry.block_labels)
     end
 end

--- a/test/problems/fermionic/fermionic.jl
+++ b/test/problems/fermionic/fermionic.jl
@@ -44,17 +44,17 @@ end
 
         # Test 4: Two operators (a_dag * a) have even parity (2 operators)
         # Before simplification, product has 2 operators
-        pair_mono = a_dag[1] * a[1]
+        pair_mono = only(monomials(a_dag[1] * a[1]))
         @test has_even_parity(pair_mono) == true
 
         # Test 5: Three operators have odd parity
         # a_dag[1] * a_dag[2] * a[1] has 3 operators
-        triple_mono = a_dag[1] * a_dag[2] * a[1]
+        triple_mono = only(monomials(a_dag[1] * a_dag[2] * a[1]))
         @test has_even_parity(triple_mono) == false
 
         # Test 6: Four operators have even parity
         # a_dag[1] * a_dag[2] * a[2] * a[1] has 4 operators
-        quad_mono = a_dag[1] * a_dag[2] * a[2] * a[1]
+        quad_mono = only(monomials(a_dag[1] * a_dag[2] * a[2] * a[1]))
         @test has_even_parity(quad_mono) == true
     end
 
@@ -65,15 +65,15 @@ end
 
         # Simplified even-parity polynomial: a_dag[1] * a[1] after normal ordering
         even_poly = simplify(a_dag[1] * a[1])
-        for t in terms(even_poly)
-            @test has_even_parity(t.monomial) == true
+        for (_, mono) in terms(even_poly)
+            @test has_even_parity(mono) == true
         end
 
         # Simplified polynomial: a[1] * a_dag[1] = delta - a_dag[1]*a[1]
         # Both identity (from delta) and number operator have even parity
         anticomm_poly = simplify(a[1] * a_dag[1])
-        for t in terms(anticomm_poly)
-            @test has_even_parity(t.monomial) == true
+        for (_, mono) in terms(anticomm_poly)
+            @test has_even_parity(mono) == true
         end
     end
 
@@ -177,10 +177,10 @@ end
 
         # Odd-parity objective: single annihilation operator (has 1 operator)
         # Need to create a Polynomial explicitly to pass to polyopt
-        odd_poly = Polynomial([Term(1.0, a[1])])
+        odd_poly = Polynomial((1.0, a[1]))
 
-        # This should throw an error because odd-parity operators have zero expectation
-        @test_throws ErrorException polyopt(odd_poly, registry)
+        # This should throw an error because the single fermionic operator is non-Hermitian
+        @test_throws ArgumentError polyopt(odd_poly, registry)
 
         # Even-parity objective should succeed
         even_poly = a_dag[1] * a[1] + a_dag[2] * a[2]
@@ -192,9 +192,9 @@ end
         registry, (a, a_dag) = create_fermionic_variables(1:2)
 
         # Pure odd-parity: just a single creation operator
-        odd_poly = Polynomial([Term(1.0, a_dag[1])])
+        odd_poly = Polynomial((1.0, a_dag[1]))
 
-        @test_throws ErrorException polyopt(odd_poly, registry)
+        @test_throws ArgumentError polyopt(odd_poly, registry)
     end
 
     @testset "Mixed parity objective rejected" begin
@@ -203,12 +203,48 @@ end
         # Mixed: has both even and odd parity terms
         # Even term: a_dag[1] * a[1] (2 operators)
         # Odd term: a[1] (1 operator)
-        even_term = Term(1.0, a_dag[1] * a[1])
-        odd_term = Term(1.0, a[1])
-        mixed_poly = Polynomial([even_term, odd_term])
+        mixed_poly = Polynomial([(1.0, only(monomials(a_dag[1] * a[1]))), (1.0, a[1])])
 
-        # Should reject because of the odd-parity term
-        @test_throws ErrorException polyopt(mixed_poly, registry)
+        # Should reject because the mixed objective is not Hermitian
+        @test_throws ArgumentError polyopt(mixed_poly, registry)
+    end
+
+    @testset "Fermionic mode-swap symmetry agrees with the ordinary path" begin
+        registry, (a, a_dag) = create_fermionic_variables(1:2)
+        ham = -(a_dag[1] * a[2] + a_dag[2] * a[1])
+        pop = polyopt(ham, registry)
+        basis = [one(a[1]), a[1], a[2], a_dag[1], a_dag[2]]
+
+        plain = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+            ),
+        )
+        symmetric = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=SymmetrySpec(
+                    fermionic_generators=[FermionicModePermutation(1 => 2, 2 => 1)],
+                    sector=FermionicSectorSpec(split_parity=true, split_number=true),
+                ),
+            ),
+        )
+
+        @test symmetric.objective ≈ plain.objective atol = 1e-6
+        @test !isnothing(symmetric.symmetry)
+        @test symmetric.symmetry.group_order == 2
+        @test symmetric.symmetry.psd_block_sizes == [1, 1, 1, 1, 1]
+        @test all(label isa FermionicSectorLabel for label in symmetric.symmetry.block_labels)
+        @test length(symmetric.symmetry.psd_block_sizes) > 1
+        @test maximum(symmetric.symmetry.psd_block_sizes) < only(flatten_sizes(plain.moment_matrix_sizes))
     end
 
 end

--- a/test/problems/fermionic/fermionic_symmetry.jl
+++ b/test/problems/fermionic/fermionic_symmetry.jl
@@ -1,0 +1,386 @@
+# Fermionic symmetry-specific regressions
+#
+# Coverage:
+# - Abelian orbital-irrep sector splitting on a finite fermionic symmetry path
+# - H₂/STO-3G molecular-orbital labels and N=2 spin-adapted order-2 regression
+# - SU(2) spin-adapted block structure on the Be 1s/2s worked example from the note
+# - low-cost Be-derived numerical slice using reviewed STO-6G one-electron integrals
+
+using Test, NCTSSoS, LinearAlgebra, TOML
+
+const FERMIONIC_SYMMETRY_EXPECTATIONS_PATH = "expectations/fermionic_symmetry.toml"
+
+const _FERMIONIC_SYMM_Z = ComplexF64[1 0; 0 -1]
+const _FERMIONIC_SYMM_I = Matrix{ComplexF64}(I, 2, 2)
+const _FERMIONIC_SYMM_SP = ComplexF64[0 1; 0 0]
+const _FERMIONIC_SYMM_SM = ComplexF64[0 0; 1 0]
+
+_z2_irrep_multiply(a, b) = a === b ? :A : :B
+_h2_irrep_multiply(a, b) = a === b ? :Ag : :B1u
+
+function _expectation_case(relpath::AbstractString, id::AbstractString)
+    data = TOML.parsefile(joinpath(pkgdir(NCTSSoS), "test", "data", relpath))
+    return only(filter(case -> case["id"] == id, data["cases"]))
+end
+
+function _fermionic_symmetry_kron_all(mats::AbstractVector{<:AbstractMatrix})
+    isempty(mats) && return Matrix{ComplexF64}(I, 1, 1)
+    return reduce(kron, mats)
+end
+
+function _fermionic_symmetry_jw_op(mode::Int, kind::Symbol, nmodes::Int)
+    mats = Vector{Matrix{ComplexF64}}(undef, nmodes)
+    for site in 1:nmodes
+        if site < mode
+            mats[site] = _FERMIONIC_SYMM_Z
+        elseif site == mode
+            mats[site] = kind === :annihilate ? _FERMIONIC_SYMM_SM : _FERMIONIC_SYMM_SP
+        else
+            mats[site] = _FERMIONIC_SYMM_I
+        end
+    end
+    return _fermionic_symmetry_kron_all(mats)
+end
+
+function _fermionic_symmetry_word_matrix(word::AbstractVector{<:Integer}, nmodes::Int)
+    dim = 2^nmodes
+    acc = Matrix{ComplexF64}(I, dim, dim)
+    for op in word
+        mode = abs(Int(op))
+        kind = op > 0 ? :annihilate : :create
+        acc = acc * _fermionic_symmetry_jw_op(mode, kind, nmodes)
+    end
+    return acc
+end
+
+function _fermionic_symmetry_poly_matrix(p::Polynomial{FermionicAlgebra,T,C}, nmodes::Int) where {T<:Integer,C<:Number}
+    dim = 2^nmodes
+    acc = zeros(ComplexF64, dim, dim)
+    for (coef, mono) in zip(coefficients(p), monomials(p))
+        acc .+= ComplexF64(coef) * _fermionic_symmetry_word_matrix(mono.word, nmodes)
+    end
+    return acc
+end
+
+function _fermionic_symmetry_sector_ground_state(H::AbstractMatrix{<:Complex}, nelectrons::Int)
+    keep = [idx for idx in 1:size(H, 1) if count_ones(UInt(idx - 1)) == nelectrons]
+    return eigmin(Hermitian(H[keep, keep]))
+end
+
+function _h2_sto3g_layout(c_up, c_dn)
+    up_modes = [Int(op.word[1]) for op in c_up]
+    dn_modes = [Int(op.word[1]) for op in c_dn]
+    return FermionicModeLayout(
+        Dict(vcat(
+            [up_modes[i] => i for i in eachindex(up_modes)],
+            [dn_modes[i] => i for i in eachindex(dn_modes)],
+        ));
+        spin2_of=Dict(vcat(
+            [up_modes[i] => 1 for i in eachindex(up_modes)],
+            [dn_modes[i] => -1 for i in eachindex(dn_modes)],
+        )),
+        irrep_of=Dict(1 => :Ag, 2 => :B1u),
+        irrep_table=AbelianIrrepTable(:Ag; multiply=_h2_irrep_multiply, dual=identity),
+    )
+end
+
+function _h2_sto3g_integrals()
+    # Reviewed offline molecular-orbital constants for the standard minimal-basis
+    # H₂ example with two spatial orbitals (σ_g, σ_u). These are electronic-only
+    # integrals; no nuclear-repulsion constant is added to the polynomial.
+    h = [
+        -1.252477303982  0.0;
+         0.0            -0.475934275367;
+    ]
+
+    v = zeros(2, 2, 2, 2)
+    v[1, 1, 1, 1] = 0.674493166046
+    v[2, 2, 2, 2] = 0.69739794957
+    v[1, 2, 1, 2] = 0.663472101055
+    v[2, 1, 2, 1] = 0.663472101055
+    v[1, 2, 2, 1] = 0.181287518306
+    v[2, 1, 1, 2] = 0.181287518306
+    v[1, 1, 2, 2] = 0.181287518306
+    v[2, 2, 1, 1] = 0.181287518306
+
+    return h, v
+end
+
+function _h2_sto3g_hamiltonian(c_up, c_up_dag, c_dn, c_dn_dag)
+    h, v = _h2_sto3g_integrals()
+    ham = zero(1.0 * one(c_up[1]))
+
+    for p in 1:2, q in 1:2
+        abs(h[p, q]) <= 1e-12 && continue
+        ham += h[p, q] * (c_up_dag[p] * c_up[q] + c_dn_dag[p] * c_dn[q])
+    end
+
+    for p in 1:2, q in 1:2, r in 1:2, s in 1:2
+        abs(v[p, q, r, s]) <= 1e-12 && continue
+        for (cσ, cσ_dag) in ((c_up, c_up_dag), (c_dn, c_dn_dag)),
+            (cτ, cτ_dag) in ((c_up, c_up_dag), (c_dn, c_dn_dag))
+            ham += 0.5 * v[p, q, r, s] * (cσ_dag[p] * cτ_dag[q] * cτ[s] * cσ[r])
+        end
+    end
+
+    return ham
+end
+
+function _h2_sto3g_problem()
+    registry, ((c_up, c_up_dag), (c_dn, c_dn_dag)) =
+        create_fermionic_variables([("c_up", 1:2), ("c_dn", 1:2)])
+
+    ham = _h2_sto3g_hamiltonian(c_up, c_up_dag, c_dn, c_dn_dag)
+    layout = _h2_sto3g_layout(c_up, c_dn)
+    sector = FermionicSectorSpec(
+        mode_layout=layout,
+        split_parity=true,
+        split_number=true,
+        split_spin=true,
+        split_irrep=true,
+    )
+    spin = FermionicSpinAdaptationSpec(mode_layout=layout)
+    n_total = sum(c_up_dag[i] * c_up[i] + c_dn_dag[i] * c_dn[i] for i in 1:2)
+    pop = polyopt(ham, registry; moment_eq_constraints=[n_total - 2.0 * one(ham)])
+    exact = _fermionic_symmetry_sector_ground_state(_fermionic_symmetry_poly_matrix(ham, 4), 2)
+
+    return pop, sector, spin, exact
+end
+
+function _be_1s_2s_layout(c_up, c_dn)
+    up_modes = [Int(op.word[1]) for op in c_up]
+    dn_modes = [Int(op.word[1]) for op in c_dn]
+    return FermionicModeLayout(
+        Dict(vcat(
+            [up_modes[i] => i for i in eachindex(up_modes)],
+            [dn_modes[i] => i for i in eachindex(dn_modes)],
+        ));
+        spin2_of=Dict(vcat(
+            [up_modes[i] => 1 for i in eachindex(up_modes)],
+            [dn_modes[i] => -1 for i in eachindex(dn_modes)],
+        )),
+        irrep_of=Dict(1 => :Ag, 2 => :Ag),
+        irrep_table=AbelianIrrepTable(:Ag; multiply=(a, b) -> :Ag, dual=identity),
+    )
+end
+
+function _be_1s_2s_one_body_problem()
+    h = [
+        -7.9386904776328775  0.27373827553230023;
+         0.27373827553230023 -1.7707398712114135;
+    ]
+
+    registry, ((c_up, c_up_dag), (c_dn, c_dn_dag)) =
+        create_fermionic_variables([("c_up", 1:2), ("c_dn", 1:2)])
+
+    ham = zero(1.0 * one(c_up[1]))
+    for p in 1:2, q in 1:2
+        ham += h[p, q] * (c_up_dag[p] * c_up[q] + c_dn_dag[p] * c_dn[q])
+    end
+
+    basis = [one(c_up[1])]
+    for (c, c_dag) in ((c_up, c_up_dag), (c_dn, c_dn_dag))
+        for p in 1:2, q in 1:2
+            push!(basis, only(monomials(c_dag[p] * c[q])))
+        end
+    end
+
+    layout = _be_1s_2s_layout(c_up, c_dn)
+    sector = FermionicSectorSpec(
+        mode_layout=layout,
+        split_parity=true,
+        split_number=true,
+        split_spin=true,
+        split_irrep=true,
+    )
+    spin = FermionicSpinAdaptationSpec(mode_layout=layout)
+    n_total = sum(c_up_dag[i] * c_up[i] + c_dn_dag[i] * c_dn[i] for i in 1:2)
+    pop = polyopt(ham, registry; moment_eq_constraints=[n_total - 2.0 * one(ham)])
+    exact = 2 * minimum(eigvals(Symmetric(h)))
+
+    return pop, basis, sector, spin, exact
+end
+
+@testset "Fermionic symmetry-specific regressions" begin
+    @testset "Abelian orbital-irrep sectors agree with the ordinary path" begin
+        reg, (a, a_dag) = create_fermionic_variables(1:4)
+        layout = FermionicModeLayout(
+            Dict(i => i for i in 1:4);
+            irrep_of=Dict(1 => :B, 2 => :B, 3 => :A, 4 => :A),
+            irrep_table=AbelianIrrepTable(:A; multiply=_z2_irrep_multiply, dual=identity),
+        )
+        symmetry = SymmetrySpec(
+            fermionic_generators=[
+                FermionicModePermutation(1 => 2, 2 => 1),
+                FermionicModePermutation(3 => 4, 4 => 3),
+            ],
+            sector=FermionicSectorSpec(
+                mode_layout=layout,
+                split_parity=true,
+                split_number=true,
+                split_irrep=true,
+            ),
+        )
+        basis = [one(a[1]), a[1], a[2], a[3], a[4], a_dag[1], a_dag[2], a_dag[3], a_dag[4]]
+        ham = -(a_dag[1] * a[2] + a_dag[2] * a[1] + a_dag[3] * a[4] + a_dag[4] * a[3])
+        pop = polyopt(ham, reg)
+
+        plain = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+            ),
+        )
+        symmetric = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=symmetry,
+            ),
+        )
+
+        @test symmetric.objective ≈ plain.objective atol = 1e-6
+        @test !isnothing(symmetric.symmetry)
+        @test maximum(symmetric.symmetry.psd_block_sizes) == 1
+        @test any(label -> label isa FermionicSectorLabel && label.irrep == :A, symmetric.symmetry.block_labels)
+        @test any(label -> label isa FermionicSectorLabel && label.irrep == :B, symmetric.symmetry.block_labels)
+        @test all(label isa FermionicSectorLabel for label in symmetric.symmetry.block_labels)
+    end
+
+    @testset "H₂/STO-3G irrep labels distinguish densities from transitions" begin
+        case = _expectation_case(FERMIONIC_SYMMETRY_EXPECTATIONS_PATH, "h2_sto3g_sector_labels")
+        expected = case["expected"]
+        reg, ((c_up, c_up_dag), (c_dn, c_dn_dag)) =
+            create_fermionic_variables([("c_up", 1:2), ("c_dn", 1:2)])
+        sector = FermionicSectorSpec(
+            mode_layout=_h2_sto3g_layout(c_up, c_dn),
+            split_parity=true,
+            split_number=true,
+            split_spin=true,
+            split_irrep=true,
+        )
+
+        density_g = NCTSSoS._fermionic_sector_label(only(monomials(c_up_dag[1] * c_up[1])), sector)
+        density_u = NCTSSoS._fermionic_sector_label(only(monomials(c_dn_dag[2] * c_dn[2])), sector)
+        transition_gu = NCTSSoS._fermionic_sector_label(only(monomials(c_up_dag[1] * c_up[2])), sector)
+        transition_ug = NCTSSoS._fermionic_sector_label(only(monomials(c_dn_dag[2] * c_dn[1])), sector)
+
+        diagonal_irrep = Symbol(expected["diagonal_irrep"])
+        transition_irrep = Symbol(expected["transition_irrep"])
+
+        @test density_g == FermionicSectorLabel(0, 0, 0, diagonal_irrep)
+        @test density_u == FermionicSectorLabel(0, 0, 0, diagonal_irrep)
+        @test transition_gu == FermionicSectorLabel(0, 0, 0, transition_irrep)
+        @test transition_ug == FermionicSectorLabel(0, 0, 0, transition_irrep)
+    end
+
+    @testset "H₂/STO-3G N=2 spin-adapted relaxation matches exact diagonalization" begin
+        oracle = expectations_oracle(FERMIONIC_SYMMETRY_EXPECTATIONS_PATH, "h2_sto3g_n2_spin_adapted")
+        pop, sector, spin, exact = _h2_sto3g_problem()
+
+        plain = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                order=2,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+            ),
+        )
+        symmetric = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                order=2,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=SymmetrySpec(sector=sector, spin_adaptation=spin),
+            ),
+        )
+
+        @test exact ≈ oracle.opt atol = 1e-10
+        @test plain.objective ≈ exact atol = 5e-6
+        @test symmetric.objective ≈ exact atol = 5e-6
+        @test symmetric.objective ≈ plain.objective atol = 5e-6
+        @test !isnothing(symmetric.symmetry)
+        @test symmetric.symmetry.psd_block_sizes == oracle.sides
+        @test maximum(symmetric.symmetry.psd_block_sizes) < only(flatten_sizes(plain.moment_matrix_sizes))
+        @test 0 in Set(label.total_spin2 for label in symmetric.symmetry.block_labels if label isa FermionicSpinBlockLabel)
+        @test 2 in Set(label.total_spin2 for label in symmetric.symmetry.block_labels if label isa FermionicSpinBlockLabel)
+        @test Set(label.sector.irrep for label in symmetric.symmetry.block_labels if label isa FermionicSpinBlockLabel) == Set([:Ag, :B1u])
+    end
+
+    @testset "Be 1s/2s worked example reproduces the [2, 2] spin blocks" begin
+        oracle = expectations_oracle(FERMIONIC_SYMMETRY_EXPECTATIONS_PATH, "be_1s_2s_spin_blocks")
+        reg, ((c_up, c_up_dag), (c_dn, c_dn_dag)) =
+            create_fermionic_variables([("c_up", 1:2), ("c_dn", 1:2)])
+        layout = _be_1s_2s_layout(c_up, c_dn)
+        sector = FermionicSectorSpec(
+            mode_layout=layout,
+            split_parity=true,
+            split_number=true,
+            split_spin=true,
+            split_irrep=true,
+        )
+        spin = FermionicSpinAdaptationSpec(mode_layout=layout)
+        active_modes = sort!(vcat([Int(op.word[1]) for op in c_up], [Int(op.word[1]) for op in c_dn]))
+        density_basis = [
+            only(monomials(c_up_dag[i] * c_up[i])) for i in 1:2
+        ]
+        append!(density_basis, [only(monomials(c_dn_dag[i] * c_dn[i])) for i in 1:2])
+        label = NCTSSoS._fermionic_sector_label(first(density_basis), sector)
+
+        blocks = NCTSSoS._fermionic_sector_transform_blocks(
+            density_basis,
+            label,
+            nothing,
+            spin,
+            active_modes,
+        )
+
+        @test [size(block.row_basis, 1) for block in blocks] == oracle.sides
+        @test [block.label.total_spin2 for block in blocks] == [0, 2]
+        @test all(block.label.sector.irrep == :Ag for block in blocks)
+    end
+
+    @testset "Be-derived 1s/2s one-body slice keeps the objective and shrinks PSD blocks" begin
+        oracle = expectations_oracle(FERMIONIC_SYMMETRY_EXPECTATIONS_PATH, "be_1s_2s_one_body_n2_order1")
+        pop, basis, sector, spin, exact = _be_1s_2s_one_body_problem()
+
+        plain = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+            ),
+        )
+        symmetric = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=SymmetrySpec(sector=sector, spin_adaptation=spin),
+            ),
+        )
+
+        @test plain.objective ≈ exact atol = 5e-6
+        @test plain.objective ≈ oracle.opt atol = 5e-6
+        @test symmetric.objective ≈ oracle.opt atol = 5e-6
+        @test symmetric.objective ≈ plain.objective atol = 5e-6
+        @test !isnothing(symmetric.symmetry)
+        @test symmetric.symmetry.psd_block_sizes == oracle.sides
+        @test maximum(symmetric.symmetry.psd_block_sizes) < only(flatten_sizes(plain.moment_matrix_sizes))
+        @test [label.total_spin2 for label in symmetric.symmetry.block_labels if label isa FermionicSpinBlockLabel] == [0, 2]
+        @test all(label.sector.irrep == :Ag for label in symmetric.symmetry.block_labels if label isa FermionicSpinBlockLabel)
+    end
+end

--- a/test/relaxations/interface.jl
+++ b/test/relaxations/interface.jl
@@ -998,7 +998,7 @@ end
                 a.word[1] => (1, b.word[1]),
                 b.word[1] => (1, a.word[1]),
             ))
-            return SymmetrySpec{T}([generator], true)
+            return SymmetrySpec([generator]; check_invariance=true)
         end
 
         function swap_group(a, b)
@@ -1077,6 +1077,66 @@ end
             end
             @test ts_err isa ArgumentError
             @test occursin("`ts_algo=NoElimination()`", sprint(showerror, ts_err))
+        end
+
+        @testset "unsupported algebra-action combinations fail loudly" begin
+            regf, (a, a_dag) = create_fermionic_variables(1:2)
+            ferm_pop = polyopt(-(a_dag[1] * a[2] + a_dag[2] * a[1]), regf)
+            ferm_basis = [one(a[1]), a[1], a[2], a_dag[1], a_dag[2]]
+
+            signed_err = symmetry_error() do
+                cs_nctssos(
+                    ferm_pop,
+                    SolverConfig(
+                        optimizer=SOLVER,
+                        moment_basis=ferm_basis,
+                        cs_algo=NoElimination(),
+                        ts_algo=NoElimination(),
+                        symmetry=SymmetrySpec(SignedPermutation(1 => 2, 2 => 1)),
+                    ),
+                )
+            end
+            @test signed_err isa ArgumentError
+            @test occursin("`SignedPermutation`", sprint(showerror, signed_err))
+
+            regm, (xm,) = create_unipotent_variables([("x", 1:2)])
+            monoid_pop = polyopt(-(1.0 * xm[1] + xm[2]), regm)
+            monoid_basis = [one(xm[1]), xm[1], xm[2]]
+            sector_err = symmetry_error() do
+                cs_nctssos(
+                    monoid_pop,
+                    SolverConfig(
+                        optimizer=SOLVER,
+                        moment_basis=monoid_basis,
+                        cs_algo=NoElimination(),
+                        ts_algo=NoElimination(),
+                        symmetry=SymmetrySpec(sector=FermionicSectorSpec(split_parity=true)),
+                    ),
+                )
+            end
+            @test sector_err isa ArgumentError
+            @test occursin("Fermionic mode permutations / sector splitting", sprint(showerror, sector_err))
+
+            up_mode = Int(a[1].word[1])
+            dn_mode = Int(a[2].word[1])
+            layout = FermionicModeLayout(
+                Dict(up_mode => 1, dn_mode => 1);
+                spin2_of=Dict(up_mode => 1, dn_mode => -1),
+            )
+            spin_without_sector_err = symmetry_error() do
+                cs_nctssos(
+                    ferm_pop,
+                    SolverConfig(
+                        optimizer=SOLVER,
+                        moment_basis=ferm_basis,
+                        cs_algo=NoElimination(),
+                        ts_algo=NoElimination(),
+                        symmetry=SymmetrySpec(spin_adaptation=FermionicSpinAdaptationSpec(mode_layout=layout)),
+                    ),
+                )
+            end
+            @test spin_without_sector_err isa ArgumentError
+            @test occursin("spin adaptation currently requires", sprint(showerror, spin_without_sector_err))
         end
     end
 end

--- a/test/relaxations/symmetry.jl
+++ b/test/relaxations/symmetry.jl
@@ -1,7 +1,7 @@
 # test/relaxations/symmetry.jl
 # Tests: fail-fast behavior for dense symmetry MVP
 
-using Test, NCTSSoS
+using Test, NCTSSoS, LinearAlgebra
 
 const SW = NCTSSoS.SymbolicWedderburn
 
@@ -38,6 +38,17 @@ function _create_chsh_symmetry(x, y)
         y[2].word[1] => x[2].word[1],
     )
     return SymmetrySpec(alice_swap, bob_swap, party_swap)
+end
+
+function _create_spinless_fermion_swap_problem()
+    reg, (a, a_dag) = create_fermionic_variables(1:2)
+    ham = -(a_dag[1] * a[2] + a_dag[2] * a[1])
+    basis = [one(a[1]), a[1], a[2], a_dag[1], a_dag[2]]
+    symmetry = SymmetrySpec(
+        fermionic_generators=[FermionicModePermutation(1 => 2, 2 => 1)],
+        sector=FermionicSectorSpec(split_parity=true, split_number=true),
+    )
+    return polyopt(ham, reg), reg, a, a_dag, basis, symmetry
 end
 
 @testset "Symmetry MVP Guards" begin
@@ -174,26 +185,283 @@ end
         end
     end
 
-    @testset "multiplicity-bearing decompositions error" begin
-        reg, (x,) = create_unipotent_variables([("x", 1:2)])
-        T = typeof(x[1].word[1])
-        spec = NCTSSoS._convert_symmetry_spec(
-            T,
-            SymmetrySpec(
-                SignedPermutation(
-                    x[1].word[1] => x[2].word[1],
-                    x[2].word[1] => x[1].word[1],
-                ),
+    @testset "fermionic signed support keeps creation and annihilation distinct" begin
+        pop, _, a, a_dag, basis, _ = _create_spinless_fermion_swap_problem()
+        cfg = SolverConfig(
+            optimizer=SOLVER,
+            moment_basis=basis,
+            cs_algo=NoElimination(),
+            ts_algo=NoElimination(),
+        )
+        sparsity = compute_sparsity(pop, cfg)
+
+        domain = NCTSSoS._symmetry_domain(pop, sparsity.corr_sparsity, sparsity.cliques_term_sparsities)
+        mode_domain = NCTSSoS._mode_symmetry_domain(pop, sparsity.corr_sparsity, sparsity.cliques_term_sparsities)
+        T = typeof(a[1].word[1])
+
+        @test domain == sort!(T[-2, -1, 1, 2])
+        @test mode_domain == [1, 2]
+        @test Set(domain) != Set(T[1, 2])
+        @test only(monomials(NCTSSoS._act_polynomial(FermionicModePermutation(1 => 2, 2 => 1), a_dag[1] * a[2]))) == only(monomials(a_dag[2] * a[1]))
+    end
+
+    @testset "signed-permutation keys are collision-free on signed domains" begin
+        domain = [-1, 1]
+        g1 = SignedPermutation(Dict(-1 => (1, -1), 1 => (1, 1)))
+        g2 = SignedPermutation(Dict(-1 => (-1, 1), 1 => (-1, -1)))
+
+        @test g1 != g2
+        @test NCTSSoS._symmetry_key(g1, domain) != NCTSSoS._symmetry_key(g2, domain)
+    end
+
+    @testset "complex transformed blocks use unitary conjugation" begin
+        reg, (σx, _, _) = create_pauli_variables(1:1)
+        one_poly = 1.0 * one(σx[1])
+        zero_poly = zero(one_poly)
+        mat = [one_poly zero_poly; zero_poly 2.0 * one_poly]
+        U = ComplexF64[1 im; 1 -im] / sqrt(2)
+
+        transformed = NCTSSoS._transform_polynomial_block(mat, U, U)
+        expected = U * ComplexF64[1 0; 0 2] * U'
+
+        for j in 1:2, i in 1:2
+            @test only(monomials(transformed[i, j])) == one(σx[1])
+            @test only(coefficients(transformed[i, j])) ≈ expected[i, j] atol = 1e-12
+        end
+    end
+
+    @testset "fermionic irrep labels compose exactly" begin
+        reg, (a, a_dag) = create_fermionic_variables(1:3)
+        c3_table = AbelianIrrepTable(0; multiply=(x, y) -> mod(x + y, 3), dual=x -> mod(-x, 3))
+        layout = FermionicModeLayout(
+            Dict(1 => 1, 2 => 2, 3 => 3);
+            irrep_of=Dict(1 => 1, 2 => 2, 3 => 1),
+            irrep_table=c3_table,
+        )
+        sector = FermionicSectorSpec(mode_layout=layout, split_irrep=true, split_parity=true)
+
+        label_create_annihilate = NCTSSoS._fermionic_sector_label(
+            only(monomials(a_dag[1] * a[2])),
+            sector,
+        )
+        label_double_create = NCTSSoS._fermionic_sector_label(
+            only(monomials(a_dag[3] * a_dag[1])),
+            sector,
+        )
+        neutral_label = NCTSSoS._fermionic_sector_label(one(a[1]), sector)
+
+        @test label_create_annihilate == FermionicSectorLabel(0, nothing, nothing, 2)
+        @test label_double_create == FermionicSectorLabel(0, nothing, nothing, 2)
+        @test neutral_label == FermionicSectorLabel(0, nothing, nothing, 0)
+
+        missing_mode_layout = FermionicModeLayout(
+            Dict(1 => 1);
+            irrep_of=Dict(1 => 1),
+            irrep_table=c3_table,
+        )
+        err = _capture_exception(() -> NCTSSoS._validate_active_fermionic_sector_metadata(
+            FermionicSectorSpec(mode_layout=missing_mode_layout, split_irrep=true),
+            [1, 2],
+        ))
+        @test err isa ArgumentError
+        @test occursin("orbital_of[2]", sprint(showerror, err))
+    end
+
+    @testset "spin Casimir transform splits a spin-zero density sector deterministically" begin
+        reg, ((c_up, c_up_dag), (c_dn, c_dn_dag)) =
+            create_fermionic_variables([("c_up", 1:1), ("c_dn", 1:1)])
+        up_mode = Int(c_up[1].word[1])
+        dn_mode = Int(c_dn[1].word[1])
+        layout = FermionicModeLayout(
+            Dict(up_mode => 1, dn_mode => 1);
+            spin2_of=Dict(up_mode => 1, dn_mode => -1),
+        )
+        sector = FermionicSectorSpec(
+            mode_layout=layout,
+            split_parity=true,
+            split_number=true,
+            split_spin=true,
+        )
+        spin = FermionicSpinAdaptationSpec(mode_layout=layout)
+        density_basis = [
+            only(monomials(c_up_dag[1] * c_up[1])),
+            only(monomials(c_dn_dag[1] * c_dn[1])),
+        ]
+        label = NCTSSoS._fermionic_sector_label(first(density_basis), sector)
+
+        blocks = NCTSSoS._fermionic_sector_transform_blocks(
+            density_basis,
+            label,
+            nothing,
+            spin,
+            [up_mode, dn_mode],
+        )
+
+        @test length(blocks) == 2
+        @test [size(block.row_basis, 1) for block in blocks] == [1, 1]
+        @test [block.label.total_spin2 for block in blocks] == [0, 2]
+        @test all(block.provenance == :sector_spin for block in blocks)
+        @test blocks[1].row_basis ≈ ComplexF64[1 1] / sqrt(2) atol = 1e-12
+        @test blocks[2].row_basis ≈ ComplexF64[1 -1] / sqrt(2) atol = 1e-12
+    end
+
+    @testset "two-orbital pair sector resolves into singlet and triplet blocks" begin
+        oracle = expectations_oracle(
+            "expectations/fermionic_symmetry.toml",
+            "two_orbital_pair_sector_spin_blocks",
+        )
+        reg, ((c_up, c_up_dag), (c_dn, c_dn_dag)) =
+            create_fermionic_variables([("c_up", 1:2), ("c_dn", 1:2)])
+        up_modes = [Int(op.word[1]) for op in c_up]
+        dn_modes = [Int(op.word[1]) for op in c_dn]
+        layout = FermionicModeLayout(
+            Dict(
+                up_modes[1] => 1,
+                up_modes[2] => 2,
+                dn_modes[1] => 1,
+                dn_modes[2] => 2,
+            );
+            spin2_of=Dict(
+                up_modes[1] => 1,
+                up_modes[2] => 1,
+                dn_modes[1] => -1,
+                dn_modes[2] => -1,
             ),
         )
-        domain = sort!(T[x[1].word[1], x[2].word[1]])
-        group = NCTSSoS._enumerate_symmetry_group(spec, domain)
-        sw_group = NCTSSoS._sw_signed_permutation_group(spec, group, domain)
-        basis = [one(x[1]), x[1], x[2]]
+        sector = FermionicSectorSpec(
+            mode_layout=layout,
+            split_parity=true,
+            split_number=true,
+            split_spin=true,
+        )
+        spin = FermionicSpinAdaptationSpec(mode_layout=layout)
+        pair_basis = [
+            only(monomials(c_up_dag[1] * c_dn_dag[1])),
+            only(monomials(c_up_dag[2] * c_dn_dag[2])),
+            only(monomials(c_up_dag[1] * c_dn_dag[2])),
+            only(monomials(c_up_dag[2] * c_dn_dag[1])),
+        ]
+        sector_label = NCTSSoS._fermionic_sector_label(first(pair_basis), sector)
 
-        err = _capture_exception(() -> NCTSSoS._sw_decompose_half_basis(basis, sw_group))
+        blocks = NCTSSoS._fermionic_sector_transform_blocks(
+            pair_basis,
+            sector_label,
+            nothing,
+            spin,
+            sort!(vcat(up_modes, dn_modes)),
+        )
+        sort!(blocks; by=block -> block.label.total_spin2)
 
-        @test err isa ArgumentError
-        @test occursin("multiplicity-free", sprint(showerror, err))
+        @test [size(block.row_basis, 1) for block in blocks] == oracle.sides
+        @test [block.label.total_spin2 for block in blocks] == [0, 2]
+        @test all(block.provenance == :sector_spin for block in blocks)
+
+        singlet_block = only(filter(block -> block.label.total_spin2 == 0, blocks))
+        triplet_block = only(filter(block -> block.label.total_spin2 == 2, blocks))
+        singlet_projector = singlet_block.row_basis' * singlet_block.row_basis
+        triplet_projector = triplet_block.row_basis' * triplet_block.row_basis
+
+        triplet_vector = ComplexF64[0, 0, 1, -1] / sqrt(2)
+        expected_triplet_projector = triplet_vector * triplet_vector'
+        singlet_mixed = ComplexF64[0, 0, 1, 1] / sqrt(2)
+        expected_singlet_projector = Diagonal(ComplexF64[1, 1, 0, 0]) + singlet_mixed * singlet_mixed'
+
+        @test triplet_projector ≈ expected_triplet_projector atol = 1e-12
+        @test singlet_projector ≈ expected_singlet_projector atol = 1e-12
+    end
+
+    @testset "fermionic symmetric moment relaxation keeps parity constraints and supports sector blocks" begin
+        pop, _, a, _, basis, symmetry = _create_spinless_fermion_swap_problem()
+        cfg = SolverConfig(
+            optimizer=SOLVER,
+            moment_basis=basis,
+            cs_algo=NoElimination(),
+            ts_algo=NoElimination(),
+        )
+        sparsity = compute_sparsity(pop, cfg)
+
+        group_only = SymmetrySpec(FermionicModePermutation(1 => 2, 2 => 1))
+        mp_group, report_group = NCTSSoS.moment_relax_symmetric(
+            pop,
+            sparsity.corr_sparsity,
+            sparsity.cliques_term_sparsities,
+            group_only,
+        )
+        mp_sector, report_sector = NCTSSoS.moment_relax_symmetric(
+            pop,
+            sparsity.corr_sparsity,
+            sparsity.cliques_term_sparsities,
+            symmetry,
+        )
+
+        @test count(c -> c[1] == :Zero, mp_group.constraints) > 0
+        @test report_group.psd_block_sizes == [3, 2]
+        @test report_sector.psd_block_sizes == [1, 1, 1, 1, 1]
+        @test count(==(:sector_wedderburn), report_sector.block_provenance) == 4
+        @test count(==(:sector_split), report_sector.block_provenance) == 1
+        @test Set(report_sector.block_labels) == Set([
+            FermionicSectorLabel(1, -1, nothing, nothing),
+            FermionicSectorLabel(1, 1, nothing, nothing),
+            FermionicSectorLabel(0, 0, nothing, nothing),
+        ])
+    end
+
+    @testset "spin-adapted symmetry path adds zero constraints for non-scalar off-blocks" begin
+        reg, ((c_up, c_up_dag), (c_dn, c_dn_dag)) =
+            create_fermionic_variables([("c_up", 1:1), ("c_dn", 1:1)])
+        up_mode = Int(c_up[1].word[1])
+        dn_mode = Int(c_dn[1].word[1])
+        layout = FermionicModeLayout(
+            Dict(up_mode => 1, dn_mode => 1);
+            spin2_of=Dict(up_mode => 1, dn_mode => -1),
+        )
+        sector = FermionicSectorSpec(
+            mode_layout=layout,
+            split_parity=true,
+            split_number=true,
+            split_spin=true,
+        )
+        spin = FermionicSpinAdaptationSpec(mode_layout=layout)
+        basis = [
+            one(c_up[1]),
+            only(monomials(c_up_dag[1] * c_up[1])),
+            only(monomials(c_dn_dag[1] * c_dn[1])),
+        ]
+        ham = -(c_up_dag[1] * c_up[1] + c_dn_dag[1] * c_dn[1])
+        pop = polyopt(ham, reg)
+        cfg = SolverConfig(
+            optimizer=SOLVER,
+            moment_basis=basis,
+            cs_algo=NoElimination(),
+            ts_algo=NoElimination(),
+        )
+        plain = cs_nctssos(pop, cfg)
+        sector_only = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=SymmetrySpec(sector=sector),
+            ),
+        )
+        spin_res = cs_nctssos(
+            pop,
+            SolverConfig(
+                optimizer=SOLVER,
+                moment_basis=basis,
+                cs_algo=NoElimination(),
+                ts_algo=NoElimination(),
+                symmetry=SymmetrySpec(sector=sector, spin_adaptation=spin),
+            ),
+        )
+
+        @test spin_res.objective ≈ plain.objective atol = 1e-6
+        @test sector_only.objective ≈ plain.objective atol = 1e-6
+        @test !isnothing(spin_res.symmetry)
+        @test spin_res.symmetry.psd_block_sizes == [2, 1]
+        @test Set(label.total_spin2 for label in spin_res.symmetry.block_labels if label isa FermionicSpinBlockLabel) == Set([0, 2])
+        @test maximum(spin_res.symmetry.psd_block_sizes) < only(flatten_sizes(plain.moment_matrix_sizes))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,8 @@ using .TestExpectations: expectations_oracle
         include("problems/condensed_matter/ising.jl")
         include("problems/condensed_matter/hubbard.jl")
         include("problems/condensed_matter/bose_hubbard.jl")
+        include("problems/fermionic/fermionic.jl")
+        include("problems/fermionic/fermionic_symmetry.jl")
         include("problems/fermionic/fermionic_chain.jl")
         include("problems/fermionic/xy_model.jl")
         include("problems/fermionic/free_fermion.jl")


### PR DESCRIPTION
## Summary

Adds opt-in symmetry-adapted basis reductions for dense fermionic ordinary-polynomial moment/SOS relaxations.

New public API:

- `FermionicModePermutation`
- `FermionicModeLayout`
- `AbelianIrrepTable`
- `FermionicSectorSpec`, `FermionicSectorLabel`
- `FermionicSpinAdaptationSpec`, `FermionicSpinBlockLabel`

The default solver path is unchanged: symmetry is only used when `SolverConfig(symmetry=...)` is supplied.

## Feature contract

This PR supports fermionic symmetry reduction for dense ordinary polynomial relaxations by:

- applying finite fermionic mode permutations while preserving creation/annihilation structure and CAR signs;
- splitting fermionic bases into parity, particle-number, spin-projection, and Abelian-irrep sectors;
- optionally applying a Casimir-based spin adaptation within sector blocks;
- reporting reduced PSD block sizes through `SymmetryReport`.

Example shape:

```julia
symmetry = SymmetrySpec(
    fermionic_generators=[FermionicModePermutation(1 => 2, 2 => 1)],
    sector=FermionicSectorSpec(split_parity=true, split_number=true),
)

cfg = SolverConfig(
    optimizer=COSMO.Optimizer,
    moment_basis=basis,
    symmetry=symmetry,
)
```

## Deliberate limits

This remains intentionally narrow:

- ordinary polynomial problems only;
- `FermionicAlgebra` only for fermionic sector/spin specs;
- dense/no-sparsity relaxations only (`NoElimination()` for CS and TS);
- no state/trace symmetry reductions;
- no composition with term-sparsity block splitting.

Unsupported combinations fail fast instead of silently producing nonsense.

## What is not included

This PR intentionally excludes the later Clifford/Pauli and SympleQ work. Those should land as follow-up PRs after this core fermionic path is reviewed.

It also omits generated docs/examples and planning/reference blobs from the original worktree, keeping this PR code/test focused.

## How to test

Passed on this branch:

```sh
julia --project -e 'using NCTSSoS; println("NCTSSoS loaded on PR branch")'
julia --project -e 'using NCTSSoS, Test; include("test/Expectations.jl"); using .TestExpectations: expectations_oracle; include("test/expectations_loader.jl"); include("test/TestUtils.jl"); include("test/relaxations/symmetry.jl")'
julia --project -e 'using NCTSSoS, Test; include("test/Expectations.jl"); using .TestExpectations: expectations_oracle; include("test/expectations_loader.jl"); include("test/TestUtils.jl"); include("test/problems/fermionic/fermionic_symmetry.jl")'
julia --project -e 'using NCTSSoS, Test; include("test/Expectations.jl"); using .TestExpectations: expectations_oracle; include("test/expectations_loader.jl"); include("test/TestUtils.jl"); include("test/relaxations/interface.jl")'
julia --project -e 'using NCTSSoS, Test; include("test/Expectations.jl"); using .TestExpectations: expectations_oracle; include("test/expectations_loader.jl"); include("test/TestUtils.jl"); include("test/problems/fermionic/fermionic.jl")'
julia --project -e 'using NCTSSoS, Test; include("test/Expectations.jl"); using .TestExpectations: expectations_oracle; include("test/expectations_loader.jl"); include("test/TestUtils.jl"); include("test/problems/condensed_matter/hubbard.jl")'
```

Full `Pkg.test()` was also run. It failed on an existing unrelated correlated-sparsity numeric tolerance:

```text
E9 chained singular on NC polydisc / n=4 dense vs sparse
315.20808181600313 ≈ 315.21023543279495 (atol=0.001)
```

The same failure reproduces on current `main`, so it is not introduced by this PR.
