### PR TITLE
feat(symmetry): recognize Pauli symmetries with SympleQ

### DIFF
--- a/docs/examples_stamp.toml
+++ b/docs/examples_stamp.toml
@@ -1,4 +1,4 @@
 format_version = 1
 generator_hash = "d816fb81d74d57bbc6f916f570e82edb01710207dac43cb36e37c12515cfa877"
 literate_hash = "7f770b948fb68d008a64969e4b745dba07b20ed7092ef1e396f23425593256d7"
-src_hash = "ad4944f837515e1a3b29ac4a5ee1ea3705daa53a4e7543668baabd1b82ca3f7a"
+src_hash = "2fcd3a79d7d28bb88d6eba217b1c3540b2a7d05e36bc2048c0171c3af935ecbe"

--- a/src/NCTSSoS.jl
+++ b/src/NCTSSoS.jl
@@ -129,6 +129,7 @@ include("optimization/v2rdm_structured.jl")
 include("optimization/moment.jl")
 include("optimization/lowering.jl")
 include("optimization/symmetry.jl")
+include("sympleq/SympleQ.jl")
 include("optimization/fermionic_irreps.jl")
 include("optimization/fermionic_spin.jl")
 include("optimization/sos.jl")
@@ -147,6 +148,8 @@ export PolyOpt, polyopt, PolyOptResult, SolverConfig
 export SignedPermutation, FermionicModePermutation, CliffordSymmetry, CliffordSymmetryGroup, FermionicModeLayout, AbelianIrrepTable
 export FermionicSectorSpec, FermionicSectorLabel, FermionicSpinAdaptationSpec, FermionicSpinBlockLabel
 export SymmetrySpec, SymmetryReport
+export SymplecticTableau, SymplecticMatrix, PhaseVector, SympleQGenerator
+export sympleq_generators, sympleq_clifford_symmetry, sympleq_symmetry_spec
 export SparsityResult, compute_sparsity
 export particle_number_constraint
 

--- a/src/sympleq/SympleQ.jl
+++ b/src/sympleq/SympleQ.jl
@@ -1,0 +1,19 @@
+# =============================================================================
+# SympleQ find-side bridge for Pauli Hamiltonian symmetries
+# =============================================================================
+#
+# This subsystem implements the public, reproducible half of SympleQ:
+# tableau construction, anticommutation/cycle graph construction,
+# colour-preserving automorphisms, symplectic synthesis, best-effort phase
+# phase solving/verification, and conversion of accepted Clifford actions into
+# the existing `SymmetrySpec` seam.
+#
+# The exploit side from the SympleQ papers is intentionally not here.
+
+include("tableau.jl")
+include("graph.jl")
+include("cycles.jl")
+include("automorphism.jl")
+include("symplectic.jl")
+include("phase.jl")
+include("bridge.jl")

--- a/src/sympleq/automorphism.jl
+++ b/src/sympleq/automorphism.jl
@@ -1,0 +1,155 @@
+# =============================================================================
+# SympleQ Step 5: colour-preserving graph automorphisms
+# =============================================================================
+
+"""
+    TermPermutation
+
+Permutation of Pauli-term vertices. `images[i] == j` means term vertex `i` maps
+to term vertex `j`.
+"""
+struct TermPermutation
+    images::Vector{Int}
+
+    function TermPermutation(images::AbstractVector{<:Integer})
+        n = length(images)
+        sorted = sort!(collect(Int, images))
+        sorted == collect(1:n) || throw(ArgumentError("TermPermutation images must be a permutation of 1:$n."))
+        return new(collect(Int, images))
+    end
+end
+
+Base.length(p::TermPermutation) = length(p.images)
+Base.getindex(p::TermPermutation, i::Integer) = p.images[i]
+Base.:(==)(a::TermPermutation, b::TermPermutation) = a.images == b.images
+Base.hash(p::TermPermutation, h::UInt) = hash(p.images, h)
+Base.isone(p::TermPermutation) = all(i -> p.images[i] == i, eachindex(p.images))
+
+function Base.show(io::IO, p::TermPermutation)
+    print(io, "TermPermutation(", p.images, ")")
+end
+
+function _automorphism_order(g::SympleQGraph)
+    n = nv(g.graph)
+    color_counts = Dict{Any,Int}()
+    for color in g.colors
+        color_counts[color] = get(color_counts, color, 0) + 1
+    end
+    return sort!(collect(1:n), by=v -> (color_counts[g.colors[v]], -Graphs.degree(g.graph, v), v))
+end
+
+function _automorphism_candidates(g::SympleQGraph)
+    n = nv(g.graph)
+    return [
+        [w for w in 1:n if g.colors[w] == g.colors[v] && Graphs.degree(g.graph, w) == Graphs.degree(g.graph, v)]
+        for v in 1:n
+    ]
+end
+
+function _automorphism_consistent(
+    graph::SimpleGraph{Int},
+    assigned::Vector{Int},
+    v::Int,
+    w::Int,
+)
+    for u in Graphs.vertices(graph)
+        image_u = assigned[u]
+        image_u == 0 && continue
+        Graphs.has_edge(graph, v, u) == Graphs.has_edge(graph, w, image_u) || return false
+    end
+    return true
+end
+
+function _enumerate_color_preserving_automorphisms(
+    g::SympleQGraph;
+    max_automorphisms::Int=100_000,
+)
+    n = nv(g.graph)
+    length(g.colors) == n || throw(ArgumentError("Graph colour vector length does not match vertex count."))
+
+    order = _automorphism_order(g)
+    candidates = _automorphism_candidates(g)
+    assigned = zeros(Int, n)
+    used = falses(n)
+    automorphisms = Vector{Int}[]
+
+    function search(depth::Int)
+        length(automorphisms) >= max_automorphisms && return nothing
+        if depth > n
+            push!(automorphisms, copy(assigned))
+            return nothing
+        end
+
+        v = order[depth]
+        for w in candidates[v]
+            used[w] && continue
+            _automorphism_consistent(g.graph, assigned, v, w) || continue
+            assigned[v] = w
+            used[w] = true
+            search(depth + 1)
+            used[w] = false
+            assigned[v] = 0
+        end
+        return nothing
+    end
+
+    search(1)
+    length(automorphisms) >= max_automorphisms && @warn(
+        "SympleQ automorphism enumeration hit max_automorphisms=$max_automorphisms; returned a truncated group."
+    )
+    return automorphisms
+end
+
+function _restrict_to_pauli_vertices(g::SympleQGraph, automorphism::Vector{Int})
+    m = length(g.pauli_vertices)
+    images = Vector{Int}(undef, m)
+    pauli_lookup = Dict(vertex => i for (i, vertex) in enumerate(g.pauli_vertices))
+
+    for (i, vertex) in enumerate(g.pauli_vertices)
+        image_vertex = automorphism[vertex]
+        images[i] = get(pauli_lookup, image_vertex, 0)
+        images[i] == 0 && throw(ArgumentError(
+            "Colour-preserving automorphism mapped Pauli vertex $vertex to non-Pauli vertex $image_vertex."
+        ))
+    end
+
+    return TermPermutation(images)
+end
+
+"""
+    automorphism_generators(graph::SympleQGraph; backend=:backtracking)
+
+Return a deterministic generating set of colour-preserving automorphisms,
+restricted to the Pauli-term vertices.
+
+No extra dependency is pulled in for this MVP. `backend=:bliss` is accepted as a
+request, but currently falls back to the deterministic in-tree backtracking
+solver with a warning; this keeps non-SympleQ users free of graph-automorphism
+binary dependencies.
+"""
+function automorphism_generators(
+    graph::SympleQGraph;
+    backend::Symbol=:backtracking,
+    max_automorphisms::Int=100_000,
+)
+    if backend in (:auto, :backtracking)
+        # native path
+    elseif backend == :bliss
+        @warn "Bliss backend is not wired yet; using the in-tree backtracking automorphism solver."
+    else
+        throw(ArgumentError("Unsupported SympleQ graph automorphism backend $backend."))
+    end
+
+    autos = _enumerate_color_preserving_automorphisms(graph; max_automorphisms)
+    restricted = TermPermutation[]
+    seen = Set{Tuple{Vararg{Int}}}()
+    for auto in autos
+        perm = _restrict_to_pauli_vertices(graph, auto)
+        key = Tuple(perm.images)
+        key in seen && continue
+        push!(seen, key)
+        isone(perm) || push!(restricted, perm)
+    end
+
+    return restricted
+end

--- a/src/sympleq/bridge.jl
+++ b/src/sympleq/bridge.jl
@@ -1,0 +1,332 @@
+# =============================================================================
+# SympleQ generator -> current CliffordSymmetry / SymmetrySpec seam
+# =============================================================================
+
+function _sympleq_check_dimensions(
+    S::SymplecticMatrix,
+    phase::PhaseVector,
+    nqubits::Integer,
+)
+    size(S.data, 1) == 2 * nqubits || throw(DimensionMismatch(
+        "Symplectic matrix dimension $(size(S.data, 1)) does not match $nqubits Pauli qubits."
+    ))
+    length(phase) == 2 * nqubits || throw(DimensionMismatch(
+        "Phase vector length $(length(phase)) does not match $nqubits Pauli qubits."
+    ))
+    return nothing
+end
+
+function _sympleq_real_phase_sign(phase_k::Integer; context::AbstractString="SympleQ Clifford image")
+    k = mod(Int(phase_k), 4)
+    k == 0 && return 1
+    k == 2 && return -1
+    throw(ArgumentError(
+        "$context produced phase i^$k, which cannot be represented as a Hermitian Pauli image with sign ±1."
+    ))
+end
+
+function _sympleq_generator_row(nqubits::Integer, site::Integer, pauli_type::Integer)
+    row = zeros(UInt8, 2 * nqubits)
+    if pauli_type == _PAULI_X_TYPE
+        row[site] = 1
+    elseif pauli_type == _PAULI_Z_TYPE
+        row[nqubits + site] = 1
+    else
+        throw(ArgumentError("Expected X/Z generator type, got Pauli type $pauli_type."))
+    end
+    return row
+end
+
+function _sympleq_generator_image(
+    S::SymplecticMatrix,
+    phase::PhaseVector,
+    ::Type{T},
+    nqubits::Integer,
+    site::Integer,
+    pauli_type::Integer,
+) where {T<:Integer}
+    row = _sympleq_generator_row(nqubits, site, pauli_type)
+    image_row = _gf2_matvec(row, S.data)
+    image_word, image_eta = _symplectic_row_to_pauli_word(image_row, T)
+    isempty(image_word) && throw(ArgumentError(
+        "SympleQ Clifford image of a non-identity Pauli generator became identity."
+    ))
+
+    # Xᵢ/Zᵢ have source η = 0. `phase` is the phase of the binary generator
+    # image; converting from binary X/Z convention back to canonical Pauli words
+    # subtracts the target word's η (Y = iXZ contributes η = 1).
+    sign = _sympleq_real_phase_sign(
+        _phase_dot(row, phase) - Int(image_eta);
+        context="SympleQ image of Pauli generator on site $site",
+    )
+    return sign, NormalMonomial{PauliAlgebra,T}(image_word)
+end
+
+function _sympleq_y_image_from_xz(
+    x_image::Tuple{Int,NormalMonomial{PauliAlgebra,T}},
+    z_image::Tuple{Int,NormalMonomial{PauliAlgebra,T}},
+) where {T<:Integer}
+    x_sign, x_mono = x_image
+    z_sign, z_mono = z_image
+    product_word, product_phase = simplify(PauliAlgebra, vcat(x_mono.word, z_mono.word))
+
+    # Y = i X Z. The Pauli simplifier returns X'Z' = i^product_phase P'.
+    total_phase = Int(product_phase) + 1 + (x_sign * z_sign == -1 ? 2 : 0)
+    y_sign = _sympleq_real_phase_sign(total_phase; context="SympleQ derived image of Pauli Y")
+    return y_sign, NormalMonomial{PauliAlgebra,T}(product_word)
+end
+
+"""
+    sympleq_clifford_symmetry(S, φ; integer_type=Int)
+    sympleq_clifford_symmetry(generator; integer_type=Int)
+
+Convert a SympleQ binary symplectic generator and phase vector into the
+[`CliffordSymmetry`](@ref) action used by `NCTSSoS`'s Pauli symmetry pipeline.
+
+The conversion keeps the honest contract: if the phase lift would map a
+Hermitian Pauli generator to an `±im` multiple of a Pauli word, it errors rather
+than smuggling a non-Clifford action into the SDP reduction.
+"""
+function sympleq_clifford_symmetry(
+    S::SymplecticMatrix,
+    phase::PhaseVector;
+    integer_type::Type{T}=Int,
+) where {T<:Integer}
+    nqubits = size(S.data, 1) ÷ 2
+    return sympleq_clifford_symmetry(S, phase, T, nqubits)
+end
+
+function sympleq_clifford_symmetry(
+    generator::SympleQGenerator;
+    integer_type::Type{T}=Int,
+) where {T<:Integer}
+    return sympleq_clifford_symmetry(generator.S, generator.phase; integer_type=T)
+end
+
+function sympleq_clifford_symmetry(
+    S::SymplecticMatrix,
+    phase::PhaseVector,
+    ::Type{T},
+    nqubits::Integer,
+) where {T<:Integer}
+    _sympleq_check_dimensions(S, phase, nqubits)
+
+    images = Dict{NormalMonomial{PauliAlgebra,T},Tuple{Int,NormalMonomial{PauliAlgebra,T}}}()
+    for site in 1:nqubits
+        source_x = _pauli_letter(T, site, _PAULI_X_TYPE)
+        source_y = _pauli_letter(T, site, _PAULI_Y_TYPE)
+        source_z = _pauli_letter(T, site, _PAULI_Z_TYPE)
+
+        x_image = _sympleq_generator_image(S, phase, T, nqubits, site, _PAULI_X_TYPE)
+        z_image = _sympleq_generator_image(S, phase, T, nqubits, site, _PAULI_Z_TYPE)
+        y_image = _sympleq_y_image_from_xz(x_image, z_image)
+
+        for (source, (sign, image)) in ((source_x, x_image), (source_y, y_image), (source_z, z_image))
+            if sign != 1 || image != source
+                images[source] = (sign, image)
+            end
+        end
+    end
+
+    return CliffordSymmetry(images; nqubits)
+end
+
+function _valid_clifford_symmetry_for_polynomial(
+    g::CliffordSymmetry,
+    H::Polynomial{PauliAlgebra,T,C},
+) where {T<:Integer,C<:Number}
+    try
+        return _act_polynomial(g, H) == H
+    catch
+        return false
+    end
+end
+
+function _sympleq_base_phase_values(S::SymplecticMatrix, nqubits::Integer)
+    values = zeros(Int8, 2 * nqubits)
+    for site in 1:nqubits
+        x_row = _sympleq_generator_row(nqubits, site, _PAULI_X_TYPE)
+        z_row = _sympleq_generator_row(nqubits, site, _PAULI_Z_TYPE)
+        _, x_eta = _symplectic_row_to_pauli_word(_gf2_matvec(x_row, S.data), Int)
+        _, z_eta = _symplectic_row_to_pauli_word(_gf2_matvec(z_row, S.data), Int)
+        values[site] = x_eta
+        values[nqubits + site] = z_eta
+    end
+    return values
+end
+
+function _sympleq_gf2_solution_space(A::AbstractMatrix{<:Integer}, b::AbstractVector{<:Integer})
+    size(A, 1) == length(b) || throw(DimensionMismatch("GF(2) solve has incompatible right-hand side."))
+    nvars = size(A, 2)
+    if isempty(b)
+        return zeros(UInt8, nvars), _gf2_nullspace_basis(zeros(UInt8, 0, nvars))
+    end
+
+    augmented = hcat(UInt8.(mod.(A, 2)), reshape(UInt8.(mod.(b, 2)), :, 1))
+    rref, pivots = _gf2_rref(augmented)
+    rhs_col = nvars + 1
+
+    for r in axes(rref, 1)
+        if all(rref[r, c] == 0 for c in 1:nvars) && rref[r, rhs_col] == 1
+            throw(ArgumentError("SympleQ phase equations are inconsistent for this graph automorphism."))
+        end
+    end
+
+    x = zeros(UInt8, nvars)
+    for (r, pivot_col) in enumerate(pivots)
+        pivot_col <= nvars || continue
+        x[pivot_col] = rref[r, rhs_col]
+    end
+    return x, _gf2_nullspace_basis(A)
+end
+
+function _sympleq_sign_bit(sign::Integer)
+    sign == 1 && return UInt8(0)
+    sign == -1 && return UInt8(1)
+    throw(ArgumentError("Expected sign ±1, got $sign."))
+end
+
+function _sympleq_coeff_ratio_sign(source, target)
+    target == source && return 1
+    target == -source && return -1
+    throw(ArgumentError(
+        "SympleQ graph automorphism maps coefficient $(repr(source)) to incompatible coefficient $(repr(target))."
+    ))
+end
+
+function _sympleq_phase_from_sign_bits(base_phase::PhaseVector, sign_bits::AbstractVector{<:Integer})
+    values = copy(base_phase.values)
+    for i in eachindex(values)
+        values[i] = Int8(mod(Int(values[i]) + 2 * Int(sign_bits[i]), 4))
+    end
+    return PhaseVector(values, true)
+end
+
+function _sympleq_active_phase_indices(tab::SymplecticTableau)
+    sites = Set{Int}()
+    for mono in tab.monomials, idx in mono.word
+        push!(sites, _pauli_site(idx))
+    end
+    active = Int[]
+    for site in sort!(collect(sites))
+        push!(active, site)
+        push!(active, tab.nqubits + site)
+    end
+    return active
+end
+
+function _sympleq_phase_vectors_for_hamiltonian(
+    tab::SymplecticTableau{T,C},
+    generator::SympleQGenerator,
+) where {T<:Integer,C<:Number}
+    nqubits = tab.nqubits
+    _sympleq_check_dimensions(generator.S, generator.phase, nqubits)
+
+    base_phase = PhaseVector(_sympleq_base_phase_values(generator.S, nqubits), true)
+    base_clifford = sympleq_clifford_symmetry(generator.S, base_phase, T, nqubits)
+
+    rhs = UInt8[]
+    sizehint!(rhs, length(tab))
+    for i in 1:length(tab)
+        j = generator.permutation.images[i]
+        sign0, image0 = _act_monomial(base_clifford, tab.monomials[i])
+        image0 == tab.monomials[j] || throw(ArgumentError(
+            "SympleQ phase solve expected term $i to map to term $j, got $image0 instead of $(tab.monomials[j])."
+        ))
+
+        desired_sign = _sympleq_coeff_ratio_sign(tab.coeffs[i], tab.coeffs[j])
+        push!(rhs, _sympleq_sign_bit(sign0 * desired_sign))
+    end
+
+    particular, kernel = _sympleq_gf2_solution_space(tab.paulis, rhs)
+    phases = PhaseVector[_sympleq_phase_from_sign_bits(base_phase, particular)]
+    active_phase_indices = _sympleq_active_phase_indices(tab)
+    for direction in kernel
+        any(idx -> direction[idx] == 1, active_phase_indices) || continue
+        push!(phases, _sympleq_phase_from_sign_bits(base_phase, particular .⊻ direction))
+    end
+    return phases
+end
+
+function _sympleq_clifford_key(g::CliffordSymmetry{T}, nqubits::Integer) where {T<:Integer}
+    return _symmetry_key(g, _clifford_letter_domain(T, nqubits))
+end
+
+function _sympleq_clifford_is_identity(g::CliffordSymmetry{T}, nqubits::Integer) where {T<:Integer}
+    domain = _clifford_letter_domain(T, nqubits)
+    return all(idx -> _clifford_action_signature(g, idx) == (1, (idx,)), domain)
+end
+
+"""
+    sympleq_symmetry_spec(H; cycle_strategy=:cycle_basis, ga_backend=:backtracking, max_automorphisms=100_000)
+
+Recognize Clifford symmetries of a Pauli Hamiltonian using SympleQ's find-side
+pipeline and return a ready-to-use [`SymmetrySpec`](@ref).
+
+The implemented pipeline is the qubit/Pauli version of SympleQ: build a binary
+symplectic tableau, encode commutation and linear-dependency structure as a
+coloured graph, enumerate colour-preserving automorphisms, synthesize candidate
+symplectic Clifford actions, convert them to `CliffordSymmetry`, and keep only
+candidates that leave `H` invariant under the existing Pauli action.
+
+This is a recognizer/bridge, not the SympleQ exploit-side qubit-tapering
+machinery. Dense/no-sparsity SDP reductions are handled by the existing
+`SolverConfig(symmetry=...)` path.
+"""
+function sympleq_symmetry_spec(
+    H::Polynomial{PauliAlgebra,T,C};
+    cycle_strategy::Symbol=:cycle_basis,
+    ga_backend::Symbol=:backtracking,
+    max_automorphisms::Int=100_000,
+) where {T<:Integer,C<:Number}
+    tab = SymplecticTableau(H)
+    tab.nqubits > 0 || throw(ArgumentError("SympleQ needs a non-constant Pauli Hamiltonian."))
+
+    generators = sympleq_generators(
+        H;
+        cycle_strategy,
+        ga_backend,
+        max_automorphisms,
+    )
+    identity_perm = TermPermutation(collect(1:length(tab)))
+    identity_S = SymplecticMatrix(_gf2_identity(2 * tab.nqubits))
+    push!(
+        generators,
+        SympleQGenerator(identity_perm, identity_S, PhaseVector(zeros(Int8, 2 * tab.nqubits), true), true),
+    )
+
+    cliffords = CliffordSymmetry{T}[]
+    seen = Set{Any}()
+
+    for generator in generators
+        phases = try
+            _sympleq_phase_vectors_for_hamiltonian(tab, generator)
+        catch err
+            @warn "Skipping SympleQ generator whose phase lift is not representable as a CliffordSymmetry." exception=(err, catch_backtrace())
+            continue
+        end
+
+        for phase in phases
+            clifford = try
+                sympleq_clifford_symmetry(generator.S, phase, T, tab.nqubits)
+            catch err
+                @warn "Skipping SympleQ phase solution that does not define a valid CliffordSymmetry." exception=(err, catch_backtrace())
+                continue
+            end
+
+            _sympleq_clifford_is_identity(clifford, tab.nqubits) && continue
+            _valid_clifford_symmetry_for_polynomial(clifford, H) || continue
+
+            key = _sympleq_clifford_key(clifford, tab.nqubits)
+            key in seen && continue
+            push!(seen, key)
+            push!(cliffords, clifford)
+        end
+    end
+
+    isempty(cliffords) && throw(ArgumentError(
+        "SympleQ did not find any nontrivial Clifford symmetry that preserves this Pauli Hamiltonian."
+    ))
+
+    return SymmetrySpec(clifford_generators=cliffords; check_invariance=true)
+end

--- a/src/sympleq/cycles.jl
+++ b/src/sympleq/cycles.jl
@@ -1,0 +1,147 @@
+# =============================================================================
+# SympleQ Step 4: cycle-basis augmentation
+# =============================================================================
+
+function _gf2_rref(A::AbstractMatrix{<:Integer})
+    B = UInt8.(mod.(A, 2))
+    nrows, ncols = size(B)
+    pivots = Int[]
+    row = 1
+
+    for col in 1:ncols
+        pivot = 0
+        for r in row:nrows
+            if B[r, col] == 1
+                pivot = r
+                break
+            end
+        end
+        pivot == 0 && continue
+
+        if pivot != row
+            B[row, :], B[pivot, :] = copy(B[pivot, :]), copy(B[row, :])
+        end
+
+        for r in 1:nrows
+            if r != row && B[r, col] == 1
+                @inbounds for c in col:ncols
+                    B[r, c] ⊻= B[row, c]
+                end
+            end
+        end
+
+        push!(pivots, col)
+        row += 1
+        row > nrows && break
+    end
+
+    return B, pivots
+end
+
+function _gf2_rank(A::AbstractMatrix{<:Integer})
+    _, pivots = _gf2_rref(A)
+    return length(pivots)
+end
+
+function _gf2_nullspace_basis(A::AbstractMatrix{<:Integer})
+    rref, pivots = _gf2_rref(A)
+    ncols = size(rref, 2)
+    pivot_set = Set(pivots)
+    free_cols = [col for col in 1:ncols if !(col in pivot_set)]
+    basis = Vector{UInt8}[]
+
+    for free_col in free_cols
+        v = zeros(UInt8, ncols)
+        v[free_col] = 1
+        for (r, pivot_col) in enumerate(pivots)
+            rref[r, free_col] == 1 && (v[pivot_col] = 1)
+        end
+        push!(basis, v)
+    end
+
+    return basis
+end
+
+function _gf2_iszero(v::AbstractVector{<:Integer})
+    return all(x -> !isodd(x), v)
+end
+
+function _gf2_row_in_span(row::AbstractVector{<:Integer}, rows::AbstractMatrix{<:Integer})
+    isempty(row) && return true
+    size(rows, 2) == length(row) || throw(DimensionMismatch("GF(2) span check has incompatible row width."))
+    isempty(rows) && return _gf2_iszero(row)
+    return _gf2_rank(vcat(UInt8.(mod.(rows, 2)), reshape(UInt8.(mod.(row, 2)), 1, :))) == _gf2_rank(rows)
+end
+
+function _gf2_independent_row_indices(A::AbstractMatrix{<:Integer})
+    selected = Int[]
+    current = zeros(UInt8, 0, size(A, 2))
+    current_rank = 0
+
+    for i in axes(A, 1)
+        candidate = vcat(current, reshape(UInt8.(mod.(A[i, :], 2)), 1, :))
+        candidate_rank = _gf2_rank(candidate)
+        if candidate_rank > current_rank
+            push!(selected, i)
+            current = candidate
+            current_rank = candidate_rank
+        end
+    end
+
+    return selected
+end
+
+"""
+    pauli_cycle_basis(tab::SymplecticTableau; cycle_strategy=:cycle_basis)
+
+Return cycles as vectors of Pauli-term vertex indices. The default and currently
+only implemented strategy is a GF(2) cycle basis of `pᵀ`, i.e. a basis for
+linear relations among tableau rows.
+
+This is deliberately *not* called "minimal circuits": the audit flags that word
+as ambiguous in SympleQ Step 4. The `cycle_strategy` keyword exists so the
+implementation can be swapped once the SympleQ source clarifies the convention.
+"""
+function pauli_cycle_basis(tab::SymplecticTableau; cycle_strategy::Symbol=:cycle_basis)
+    cycle_strategy == :cycle_basis || throw(ArgumentError(
+        "Unsupported SympleQ cycle strategy $cycle_strategy. Implemented: :cycle_basis."
+    ))
+
+    isempty(tab.paulis) && return Vector{Int}[]
+    null_basis = _gf2_nullspace_basis(transpose(tab.paulis))
+    cycles = Vector{Int}[]
+    for relation in null_basis
+        cycle = findall(==(UInt8(1)), relation)
+        isempty(cycle) || push!(cycles, cycle)
+    end
+    return cycles
+end
+
+"""
+    cycle_augmented_graph(tab; cycle_strategy=:cycle_basis)
+
+Build the Step-4 graph by adding one green auxiliary vertex for each selected
+cycle and connecting it to every Pauli-term vertex in that cycle.
+"""
+function cycle_augmented_graph(tab::SymplecticTableau; cycle_strategy::Symbol=:cycle_basis)
+    base = anticommutation_graph(tab)
+    cycles = pauli_cycle_basis(tab; cycle_strategy)
+    graph = SimpleGraph(nv(base.graph) + length(cycles))
+
+    for edge in edges(base.graph)
+        add_edge!(graph, src(edge), dst(edge))
+    end
+
+    colors = copy(base.colors)
+    auxiliary_vertices = Int[]
+    for (cycle_idx, cycle) in enumerate(cycles)
+        aux = length(base.pauli_vertices) + cycle_idx
+        push!(auxiliary_vertices, aux)
+        push!(colors, (:cycle, cycle_strategy))
+        for vertex in cycle
+            add_edge!(graph, aux, vertex)
+        end
+    end
+
+    return SympleQGraph(graph, colors, copy(base.pauli_vertices), auxiliary_vertices, cycles)
+end

--- a/src/sympleq/graph.jl
+++ b/src/sympleq/graph.jl
@@ -1,0 +1,83 @@
+# =============================================================================
+# SympleQ Step 3: symplectic products and coloured anticommutation graph
+# =============================================================================
+
+"""
+    SympleQGraph
+
+Coloured graph used for SympleQ automorphism discovery.
+
+The first `length(pauli_vertices)` vertices are Pauli-term vertices. Auxiliary
+cycle vertices, when present, are stored after them and coloured separately so a
+colour-preserving automorphism cannot confuse terms with cycle constraints.
+"""
+struct SympleQGraph
+    graph::SimpleGraph{Int}
+    colors::Vector{Any}
+    pauli_vertices::Vector{Int}
+    auxiliary_vertices::Vector{Int}
+    cycles::Vector{Vector{Int}}
+end
+
+function Base.show(io::IO, g::SympleQGraph)
+    print(
+        io,
+        "SympleQGraph($(nv(g.graph)) vertices, $(ne(g.graph)) edges, " *
+        "$(length(g.pauli_vertices)) Pauli vertices, $(length(g.auxiliary_vertices)) cycle vertices)",
+    )
+end
+
+@inline function _symplectic_product_rows(
+    a::AbstractVector{<:Integer},
+    b::AbstractVector{<:Integer},
+)
+    length(a) == length(b) || throw(DimensionMismatch("Symplectic rows have different lengths."))
+    iseven(length(a)) || throw(ArgumentError("Symplectic rows must have even length."))
+    n = length(a) ÷ 2
+    acc = 0
+    @inbounds for i in 1:n
+        acc ⊻= (Int(a[i] & b[n + i]) & 1)
+        acc ⊻= (Int(a[n + i] & b[i]) & 1)
+    end
+    return UInt8(acc & 1)
+end
+
+"""
+    symplectic_product_matrix(tab::SymplecticTableau)
+
+Return the binary matrix whose `(i,j)` entry is the Pauli symplectic product
+`⟨pᵢ,pⱼ⟩ = xᵢ⋅zⱼ + zᵢ⋅xⱼ (mod 2)`.
+"""
+function symplectic_product_matrix(tab::SymplecticTableau)
+    m = length(tab)
+    products = zeros(UInt8, m, m)
+    for j in 1:m, i in 1:(j - 1)
+        value = _symplectic_product_rows(view(tab.paulis, i, :), view(tab.paulis, j, :))
+        products[i, j] = value
+        products[j, i] = value
+    end
+    return products
+end
+
+_term_color(coef, _eta::Integer) = (:pauli, abs(coef))
+
+"""
+    anticommutation_graph(tab::SymplecticTableau)
+
+Build the colour-preserving graph for SympleQ Steps 1--3: Pauli-term vertices
+are coloured by coefficient magnitude, with an edge for each anticommuting
+pair. The canonical word phase `η` and coefficient sign/phase are handled by
+the later Clifford phase lift; making them graph colours would incorrectly
+reject valid Clifford symmetries such as global `S` rotations that exchange `X`
+and `Y` terms.
+"""
+function anticommutation_graph(tab::SymplecticTableau)
+    m = length(tab)
+    graph = SimpleGraph(m)
+    products = symplectic_product_matrix(tab)
+    for j in 1:m, i in 1:(j - 1)
+        products[i, j] == 1 && add_edge!(graph, i, j)
+    end
+    colors = Any[_term_color(tab.coeffs[i], tab.eta[i]) for i in 1:m]
+    return SympleQGraph(graph, colors, collect(1:m), Int[], Vector{Int}[])
+end

--- a/src/sympleq/phase.jl
+++ b/src/sympleq/phase.jl
@@ -1,0 +1,106 @@
+# =============================================================================
+# SympleQ Step 7: best-effort phase verification
+# =============================================================================
+
+"""
+    PhaseVector
+
+`ℤ₄` phase corrections for images of the `2n` binary Pauli generators. This MVP
+keeps the vector explicit and marks whether it was verified against the tableau.
+"""
+struct PhaseVector
+    values::Vector{Int8}
+    verified::Bool
+
+    function PhaseVector(values::AbstractVector{<:Integer}, verified::Bool)
+        return new(Int8[mod(Int(v), 4) for v in values], verified)
+    end
+end
+
+Base.length(φ::PhaseVector) = length(φ.values)
+Base.getindex(φ::PhaseVector, i::Integer) = φ.values[i]
+
+"""
+    SympleQGenerator
+
+A candidate Clifford symmetry found by SympleQ's find side.
+
+`phase_verified=false` is not swept under the rug. It means the binary
+symplectic action was found, but the companion-paper phase lift was not proven
+from the available public specification.
+"""
+struct SympleQGenerator
+    permutation::TermPermutation
+    S::SymplecticMatrix
+    phase::PhaseVector
+    phase_verified::Bool
+end
+
+function _phase_dot(row::AbstractVector{<:Integer}, phase::PhaseVector)
+    length(row) == length(phase) || throw(DimensionMismatch("Phase vector length does not match symplectic row."))
+    acc = 0
+    for i in eachindex(row)
+        isodd(row[i]) && (acc += Int(phase[i]))
+    end
+    return mod(acc, 4)
+end
+
+function _verify_zero_phase_lift(tab::SymplecticTableau, perm::TermPermutation, S::SymplecticMatrix)
+    _gf2_matmul(tab.paulis, S.data) == tab.paulis[perm.images, :] || return false
+
+    # This is intentionally conservative. Public SympleQ text does not pin down
+    # Step 7's phase recovery. A zero phase vector is verified only when the
+    # canonical Pauli-word phases and coefficients already match the term
+    # permutation. More exotic Clifford phases are returned as unverified.
+    for i in 1:length(tab)
+        j = perm.images[i]
+        tab.eta[i] == tab.eta[j] || return false
+        tab.coeffs[i] == tab.coeffs[j] || return false
+    end
+    return true
+end
+
+"""
+    recover_phase_vector(tab, perm, S)
+
+Best-effort Step-7 phase recovery for the raw generator list. It verifies the
+zero phase lift and otherwise returns `phase_verified=false`; the public
+`sympleq_symmetry_spec` bridge performs a Hamiltonian-specific GF(2) phase solve
+before accepting a Clifford action.
+"""
+function recover_phase_vector(tab::SymplecticTableau, perm::TermPermutation, S::SymplecticMatrix)
+    values = zeros(Int8, size(S.data, 1))
+    verified = _verify_zero_phase_lift(tab, perm, S)
+    return PhaseVector(values, verified)
+end
+
+"""
+    sympleq_generators(H; cycle_strategy=:cycle_basis, ga_backend=:backtracking)
+
+Run SympleQ find-side Steps 1--7 and return candidate binary Clifford
+generators.
+"""
+function sympleq_generators(
+    H::Polynomial{PauliAlgebra,T,C};
+    cycle_strategy::Symbol=:cycle_basis,
+    ga_backend::Symbol=:backtracking,
+    max_automorphisms::Int=100_000,
+) where {T<:Integer,C<:Number}
+    tab = SymplecticTableau(H)
+    graph = cycle_augmented_graph(tab; cycle_strategy)
+    perms = automorphism_generators(graph; backend=ga_backend, max_automorphisms)
+    generators = SympleQGenerator[]
+
+    for perm in perms
+        S = try
+            symplectic_matrix_from_permutation(tab, perm)
+        catch err
+            @warn "Skipping graph automorphism that is not a symplectic tableau action." exception=(err, catch_backtrace())
+            continue
+        end
+        phase = recover_phase_vector(tab, perm, S)
+        push!(generators, SympleQGenerator(perm, S, phase, phase.verified))
+    end
+
+    return generators
+end

--- a/src/sympleq/symplectic.jl
+++ b/src/sympleq/symplectic.jl
@@ -1,0 +1,239 @@
+# =============================================================================
+# SympleQ Step 6: synthesize binary symplectic S from a term permutation
+# =============================================================================
+
+"""
+    SymplecticMatrix
+
+Binary row-convention symplectic matrix. A Pauli row vector `p` maps to `p*S`.
+"""
+struct SymplecticMatrix
+    data::Matrix{UInt8}
+
+    function SymplecticMatrix(data::AbstractMatrix{<:Integer})
+        size(data, 1) == size(data, 2) || throw(ArgumentError("SymplecticMatrix must be square."))
+        iseven(size(data, 1)) || throw(ArgumentError("SymplecticMatrix dimension must be even."))
+        mat = UInt8.(mod.(data, 2))
+        return new(mat)
+    end
+end
+
+Base.size(S::SymplecticMatrix) = size(S.data)
+Base.getindex(S::SymplecticMatrix, i::Integer, j::Integer) = S.data[i, j]
+Base.Matrix(S::SymplecticMatrix) = copy(S.data)
+
+function Base.show(io::IO, S::SymplecticMatrix)
+    print(io, "SymplecticMatrix($(size(S.data, 1))×$(size(S.data, 2)))")
+end
+
+function _gf2_matmul(A::AbstractMatrix{<:Integer}, B::AbstractMatrix{<:Integer})
+    size(A, 2) == size(B, 1) || throw(DimensionMismatch("GF(2) matrix product dimension mismatch."))
+    C = zeros(UInt8, size(A, 1), size(B, 2))
+    @inbounds for i in axes(A, 1), k in axes(A, 2)
+        isodd(A[i, k]) || continue
+        for j in axes(B, 2)
+            C[i, j] ⊻= UInt8(isodd(B[k, j]))
+        end
+    end
+    return C
+end
+
+function _gf2_matvec(row::AbstractVector{<:Integer}, S::AbstractMatrix{<:Integer})
+    length(row) == size(S, 1) || throw(DimensionMismatch("GF(2) row/matrix product dimension mismatch."))
+    out = zeros(UInt8, size(S, 2))
+    @inbounds for k in eachindex(row)
+        isodd(row[k]) || continue
+        for j in axes(S, 2)
+            out[j] ⊻= UInt8(isodd(S[k, j]))
+        end
+    end
+    return out
+end
+
+function _gf2_identity(n::Integer)
+    I = zeros(UInt8, n, n)
+    for i in 1:n
+        I[i, i] = 1
+    end
+    return I
+end
+
+function _gf2_inverse(A::AbstractMatrix{<:Integer})
+    n, m = size(A)
+    n == m || throw(ArgumentError("GF(2) inverse requires a square matrix."))
+    B = hcat(UInt8.(mod.(A, 2)), _gf2_identity(n))
+    row = 1
+
+    for col in 1:n
+        pivot = 0
+        for r in row:n
+            if B[r, col] == 1
+                pivot = r
+                break
+            end
+        end
+        pivot == 0 && throw(ArgumentError("Matrix is singular over GF(2)."))
+
+        if pivot != row
+            B[row, :], B[pivot, :] = copy(B[pivot, :]), copy(B[row, :])
+        end
+
+        for r in 1:n
+            if r != row && B[r, col] == 1
+                @inbounds for c in col:(2n)
+                    B[r, c] ⊻= B[row, c]
+                end
+            end
+        end
+        row += 1
+    end
+
+    return B[:, (n + 1):(2n)]
+end
+
+function symplectic_form(nqubits::Integer)
+    Ω = zeros(UInt8, 2 * nqubits, 2 * nqubits)
+    for i in 1:nqubits
+        Ω[i, nqubits + i] = 1
+        Ω[nqubits + i, i] = 1
+    end
+    return Ω
+end
+
+function _gf2_pairing(a::AbstractVector{<:Integer}, b::AbstractVector{<:Integer})
+    return _symplectic_product_rows(a, b)
+end
+
+function _gf2_append_row(rows::AbstractMatrix{<:Integer}, row::AbstractVector{<:Integer})
+    return vcat(UInt8.(mod.(rows, 2)), reshape(UInt8.(mod.(row, 2)), 1, :))
+end
+
+function _all_gf2_vectors(dim::Integer)
+    dim <= 20 || throw(ArgumentError(
+        "SympleQ rank-deficient synthesis currently enumerates GF(2)^$dim; refusing dimensions > 20."
+    ))
+    vectors = Vector{UInt8}[]
+    sizehint!(vectors, 2^dim)
+    for mask in 0:(UInt(1) << dim) - UInt(1)
+        v = zeros(UInt8, dim)
+        for bit in 1:dim
+            ((mask >> (bit - 1)) & UInt(1)) == UInt(1) && (v[bit] = 1)
+        end
+        push!(vectors, v)
+    end
+    return vectors
+end
+
+function _standard_gf2_vectors(dim::Integer)
+    vectors = Vector{UInt8}[]
+    for i in 1:dim
+        v = zeros(UInt8, dim)
+        v[i] = 1
+        push!(vectors, v)
+    end
+    return vectors
+end
+
+function _choose_domain_extension(D::AbstractMatrix{<:Integer})
+    dim = size(D, 2)
+    for v in _standard_gf2_vectors(dim)
+        _gf2_row_in_span(v, D) || return v
+    end
+    for v in _all_gf2_vectors(dim)
+        _gf2_row_in_span(v, D) || return v
+    end
+    throw(ArgumentError("No independent GF(2) domain extension vector exists."))
+end
+
+function _choose_target_extension(
+    domain_vector::AbstractVector{<:Integer},
+    D::AbstractMatrix{<:Integer},
+    R::AbstractMatrix{<:Integer},
+)
+    dim = size(R, 2)
+    for candidate in _all_gf2_vectors(dim)
+        _gf2_row_in_span(candidate, R) && continue
+        ok = true
+        for i in axes(D, 1)
+            if _gf2_pairing(domain_vector, view(D, i, :)) != _gf2_pairing(candidate, view(R, i, :))
+                ok = false
+                break
+            end
+        end
+        ok && return candidate
+    end
+    throw(ArgumentError(
+        "Failed to extend the partial Pauli isometry to a full symplectic basis. " *
+        "The graph automorphism may not preserve the tableau's linear relations."
+    ))
+end
+
+function _extend_symplectic_isometry(
+    domain_rows::AbstractMatrix{<:Integer},
+    target_rows::AbstractMatrix{<:Integer},
+)
+    size(domain_rows) == size(target_rows) || throw(DimensionMismatch("Domain and target bases must have the same shape."))
+    dim = size(domain_rows, 2)
+    D = UInt8.(mod.(domain_rows, 2))
+    R = UInt8.(mod.(target_rows, 2))
+
+    _gf2_rank(D) == size(D, 1) || throw(ArgumentError("Domain rows are not independent over GF(2)."))
+    _gf2_rank(R) == size(R, 1) || throw(ArgumentError("Target rows are not independent over GF(2)."))
+
+    while size(D, 1) < dim
+        d = _choose_domain_extension(D)
+        r = _choose_target_extension(d, D, R)
+        D = _gf2_append_row(D, d)
+        R = _gf2_append_row(R, r)
+    end
+
+    return D, R
+end
+
+"""
+    is_symplectic_matrix(S::SymplecticMatrix)
+
+Check `S Ω Sᵀ = Ω` over GF(2), matching the row-vector convention used by this
+subsystem.
+"""
+function is_symplectic_matrix(S::SymplecticMatrix)
+    dim = size(S.data, 1)
+    Ω = symplectic_form(dim ÷ 2)
+    return _gf2_matmul(_gf2_matmul(S.data, Ω), transpose(S.data)) == Ω
+end
+
+"""
+    symplectic_matrix_from_permutation(tab, perm)
+
+Synthesize a row-convention binary symplectic matrix `S` satisfying
+`tab.paulis * S == tab.paulis[perm.images, :]` over GF(2) whenever the supplied
+term permutation induces a Pauli isometry.
+
+Rank-deficient tableaux are extended by a small finite-field Witt-extension
+search. That is the explicit, testable patch for the Step-6 corner case.
+"""
+function symplectic_matrix_from_permutation(tab::SymplecticTableau, perm::TermPermutation)
+    length(perm) == length(tab) || throw(ArgumentError("Permutation length does not match tableau term count."))
+    dim = 2 * tab.nqubits
+    dim == 0 && return SymplecticMatrix(zeros(UInt8, 0, 0))
+
+    P = UInt8.(tab.paulis)
+    Q = P[perm.images, :]
+    basis_indices = _gf2_independent_row_indices(P)
+
+    if isempty(basis_indices)
+        return SymplecticMatrix(_gf2_identity(dim))
+    end
+
+    D0 = P[basis_indices, :]
+    R0 = Q[basis_indices, :]
+    D, R = _extend_symplectic_isometry(D0, R0)
+    S = SymplecticMatrix(_gf2_matmul(_gf2_inverse(D), R))
+
+    is_symplectic_matrix(S) || throw(ArgumentError("Synthesized matrix is not symplectic over GF(2)."))
+    _gf2_matmul(P, S.data) == Q || throw(ArgumentError(
+        "Synthesized symplectic matrix does not reproduce the requested term permutation."
+    ))
+
+    return S
+end

--- a/src/sympleq/tableau.jl
+++ b/src/sympleq/tableau.jl
@@ -1,0 +1,129 @@
+# =============================================================================
+# SympleQ Steps 1--2: Pauli polynomial -> binary symplectic tableau
+# =============================================================================
+
+"""
+    SymplecticTableau
+
+Pauli Hamiltonian tableau used by the find-side SympleQ pipeline.
+
+Rows correspond to nonzero Pauli terms. `paulis[i, :]` is the binary vector
+`(x₁,…,xₙ,z₁,…,zₙ)` for term `i`; `eta[i]` is the canonical Pauli-word phase in
+`ℤ₄` from writing `Y = iXZ`. Polynomial coefficients are stored separately and
+are used as graph colours.
+"""
+struct SymplecticTableau{T<:Integer,C<:Number}
+    coeffs::Vector{C}
+    paulis::Matrix{UInt8}
+    eta::Vector{Int8}
+    monomials::Vector{NormalMonomial{PauliAlgebra,T}}
+    nqubits::Int
+end
+
+Base.length(tab::SymplecticTableau) = length(tab.monomials)
+Base.size(tab::SymplecticTableau) = size(tab.paulis)
+
+function Base.show(io::IO, tab::SymplecticTableau)
+    print(io, "SymplecticTableau($(length(tab)) terms, $(tab.nqubits) qubits)")
+end
+
+@inline _gf2(x::Integer) = UInt8(isodd(x) ? 1 : 0)
+
+function _pauli_nqubits(poly::Polynomial{PauliAlgebra,T,C}) where {T<:Integer,C<:Number}
+    max_site = 0
+    for (_, mono) in poly.terms, idx in mono.word
+        max_site = max(max_site, _pauli_site(idx))
+    end
+    return max_site
+end
+
+function _pauli_word_to_symplectic(
+    mono::NormalMonomial{PauliAlgebra,T},
+    nqubits::Integer,
+) where {T<:Integer}
+    row = zeros(UInt8, 2 * nqubits)
+    eta = Int8(0)
+
+    for idx in mono.word
+        site = _pauli_site(idx)
+        site <= nqubits || throw(ArgumentError(
+            "Pauli word contains site $site but tableau has only $nqubits qubits."
+        ))
+        typ = _pauli_type(idx)
+        if typ == 0          # X
+            row[site] = 1
+        elseif typ == 1      # Y = iXZ
+            row[site] = 1
+            row[nqubits + site] = 1
+            eta = Int8(mod(Int(eta) + 1, 4))
+        elseif typ == 2      # Z
+            row[nqubits + site] = 1
+        else
+            throw(ArgumentError("Invalid Pauli type $typ for index $idx."))
+        end
+    end
+
+    return row, eta
+end
+
+function _symplectic_row_to_pauli_word(
+    row::AbstractVector{<:Integer},
+    ::Type{T}=UInt8,
+) where {T<:Integer}
+    iseven(length(row)) || throw(ArgumentError("Symplectic rows must have even length."))
+    nqubits = length(row) ÷ 2
+    word = T[]
+    eta = Int8(0)
+
+    for site in 1:nqubits
+        x = isodd(row[site])
+        z = isodd(row[nqubits + site])
+        if x && z
+            push!(word, T(_pauli_index(site, 1)))
+            eta = Int8(mod(Int(eta) + 1, 4))
+        elseif x
+            push!(word, T(_pauli_index(site, 0)))
+        elseif z
+            push!(word, T(_pauli_index(site, 2)))
+        end
+    end
+
+    return word, eta
+end
+
+function _single_pauli_letter_from_symplectic(
+    row::AbstractVector{<:Integer},
+    ::Type{T}=UInt8,
+) where {T<:Integer}
+    word, eta = _symplectic_row_to_pauli_word(row, T)
+    length(word) == 1 || return nothing
+    return only(word), eta
+end
+
+"""
+    SymplecticTableau(H::Polynomial{PauliAlgebra})
+
+Construct the binary symplectic tableau for a Pauli polynomial. Identity terms
+are allowed; they become all-zero rows and are usually irrelevant for graph
+automorphisms.
+"""
+function SymplecticTableau(poly::Polynomial{PauliAlgebra,T,C}) where {T<:Integer,C<:Number}
+    nqubits = _pauli_nqubits(poly)
+    m = length(poly.terms)
+    paulis = zeros(UInt8, m, 2 * nqubits)
+    eta = Vector{Int8}(undef, m)
+    coeffs = Vector{C}(undef, m)
+    monos = Vector{NormalMonomial{PauliAlgebra,T}}(undef, m)
+
+    for (i, (coef, mono)) in enumerate(poly.terms)
+        row, row_eta = _pauli_word_to_symplectic(mono, nqubits)
+        if !isempty(row)
+            paulis[i, :] .= row
+        end
+        eta[i] = row_eta
+        coeffs[i] = coef
+        monos[i] = mono
+    end
+
+    return SymplecticTableau{T,C}(coeffs, paulis, eta, monos, nqubits)
+end

--- a/test/relaxations/symmetry.jl
+++ b/test/relaxations/symmetry.jl
@@ -330,6 +330,76 @@ end
         end
     end
 
+    @testset "SympleQ deterministic internals" begin
+        reg, (σx, σy, σz) = create_pauli_variables(1:3)
+        hamiltonian = 2.0 * σx[1] + 2.0 * σz[1] + 3.0 * σx[2] * σz[3]
+        tab = SymplecticTableau(hamiltonian)
+
+        @test length(tab) == 3
+        @test size(tab) == (3, 6)
+        @test sprint(show, tab) == "SymplecticTableau(3 terms, 3 qubits)"
+        @test tab.coeffs == [2.0 + 0.0im, 2.0 + 0.0im, 3.0 + 0.0im]
+        @test tab.nqubits == 3
+
+        y_row, y_eta = NCTSSoS._pauli_word_to_symplectic(σy[2], 3)
+        @test y_eta == 1
+        @test y_row == UInt8[0, 1, 0, 0, 1, 0]
+        y_word, eta_back = NCTSSoS._symplectic_row_to_pauli_word(y_row, UInt8)
+        @test eta_back == 1
+        @test y_word == σy[2].word
+        @test NCTSSoS._single_pauli_letter_from_symplectic(y_row, UInt8) == (only(σy[2].word), Int8(1))
+        @test isnothing(NCTSSoS._single_pauli_letter_from_symplectic(UInt8[1, 1, 0, 0], UInt8))
+
+        products = NCTSSoS.symplectic_product_matrix(tab)
+        @test products == UInt8[0 1 0; 1 0 0; 0 0 0]
+        graph = NCTSSoS.anticommutation_graph(tab)
+        @test sprint(show, graph) == "SympleQGraph(3 vertices, 1 edges, 3 Pauli vertices, 0 cycle vertices)"
+        @test graph.colors == [(:pauli, 2.0), (:pauli, 2.0), (:pauli, 3.0)]
+
+        cycle_tab = SymplecticTableau(1.0 * (σx[1] + σx[2] + σx[1] * σx[2]))
+        @test NCTSSoS.pauli_cycle_basis(cycle_tab) == [[1, 2, 3]]
+        augmented = NCTSSoS.cycle_augmented_graph(cycle_tab)
+        @test augmented.cycles == [[1, 2, 3]]
+        @test augmented.auxiliary_vertices == [4]
+        @test_throws ArgumentError NCTSSoS.pauli_cycle_basis(cycle_tab; cycle_strategy=:minimal_circuits)
+
+        @test_throws ArgumentError NCTSSoS.TermPermutation([1, 1])
+        swap_perm = NCTSSoS.TermPermutation([2, 1, 3])
+        @test length(swap_perm) == 3
+        @test swap_perm[1] == 2
+        @test !isone(swap_perm)
+        @test sprint(show, swap_perm) == "TermPermutation([2, 1, 3])"
+
+        automorphisms = NCTSSoS.automorphism_generators(graph; backend=:backtracking)
+        @test any(perm -> perm.images == [2, 1, 3], automorphisms)
+        @test NCTSSoS.automorphism_generators(graph; backend=:bliss) == automorphisms
+        @test_throws ArgumentError NCTSSoS.automorphism_generators(graph; backend=:nauty)
+
+        S = NCTSSoS.symplectic_matrix_from_permutation(tab, swap_perm)
+        @test sprint(show, S) == "SymplecticMatrix(6×6)"
+        @test size(S) == (6, 6)
+        @test Matrix(S) == S.data
+        @test NCTSSoS.is_symplectic_matrix(S)
+        @test NCTSSoS._gf2_matmul(tab.paulis, S.data) == tab.paulis[swap_perm.images, :]
+        @test_throws ArgumentError NCTSSoS.symplectic_matrix_from_permutation(tab, NCTSSoS.TermPermutation([1, 2]))
+        @test_throws ArgumentError NCTSSoS.SymplecticMatrix(ones(Int, 2, 3))
+        @test_throws ArgumentError NCTSSoS.SymplecticMatrix(ones(Int, 3, 3))
+
+        phase = PhaseVector(zeros(Int8, 6), true)
+        @test length(phase) == 6
+        @test phase[1] == 0
+        generator = NCTSSoS.SympleQGenerator(swap_perm, S, phase, true)
+        clifford = sympleq_clifford_symmetry(generator; integer_type=UInt8)
+        @test NCTSSoS._act_polynomial(clifford, hamiltonian) == hamiltonian
+        @test NCTSSoS._act_monomial(clifford, σx[1]) == (1, σz[1])
+        @test NCTSSoS._act_monomial(clifford, σz[1]) == (1, σx[1])
+
+        recovered_phase = NCTSSoS.recover_phase_vector(tab, swap_perm, S)
+        @test recovered_phase.verified
+        @test NCTSSoS.sympleq_generators(hamiltonian) isa Vector{NCTSSoS.SympleQGenerator}
+        @test_throws ArgumentError sympleq_symmetry_spec(1.0 * one(σx[1]))
+    end
+
     @testset "symmetry helpers cover invariant constraints and scalar reductions" begin
         reg, (x,) = create_unipotent_variables([("x", 1:2)])
         invariant_poly = 1.0 * (x[1] + x[2])

--- a/test/relaxations/symmetry.jl
+++ b/test/relaxations/symmetry.jl
@@ -269,6 +269,67 @@ end
         @test z_report.psd_block_sizes == [2]
     end
 
+    @testset "SympleQ recognizes Pauli Hamiltonian Clifford symmetry" begin
+        reg, (σx, σy, σz) = create_pauli_variables(1:1)
+        hamiltonian = 1.0 * (σx[1] + σz[1])
+        spec = sympleq_symmetry_spec(hamiltonian)
+
+        swap_idx = findfirst(spec.clifford_generators) do g
+            NCTSSoS._act_polynomial(g, hamiltonian) == hamiltonian &&
+                NCTSSoS._act_monomial(g, σx[1]) == (1, σz[1]) &&
+                NCTSSoS._act_monomial(g, σz[1]) == (1, σx[1]) &&
+                NCTSSoS._act_monomial(g, σy[1]) == (-1, σy[1])
+        end
+        @test !isnothing(swap_idx)
+        generator = spec.clifford_generators[swap_idx]
+
+        fixed_term = 1.0 * σx[1]
+        fixed_spec = sympleq_symmetry_spec(fixed_term)
+        @test any(fixed_spec.clifford_generators) do g
+            NCTSSoS._act_polynomial(g, fixed_term) == fixed_term &&
+                NCTSSoS._act_monomial(g, σx[1]) == (1, σx[1]) &&
+                NCTSSoS._act_monomial(g, σz[1]) == (-1, σz[1])
+        end
+
+        signed_hamiltonian = 1.0 * (σx[1] - σz[1])
+        signed_generators = sympleq_symmetry_spec(signed_hamiltonian).clifford_generators
+        @test any(signed_generators) do g
+            NCTSSoS._act_polynomial(g, signed_hamiltonian) == signed_hamiltonian &&
+                NCTSSoS._act_monomial(g, σx[1]) == (-1, σz[1]) &&
+                NCTSSoS._act_monomial(g, σz[1]) == (-1, σx[1])
+        end
+
+        pop = polyopt(hamiltonian, reg)
+        basis = [one(σx[1]), σx[1], σz[1]]
+        cfg = SolverConfig(
+            optimizer=nothing,
+            moment_basis=basis,
+            cs_algo=NoElimination(),
+            ts_algo=NoElimination(),
+            symmetry=spec,
+        )
+        sparsity = compute_sparsity(pop, cfg)
+        @test NCTSSoS._check_symmetry_mvp_support(pop, cfg, sparsity) === nothing
+        _, report = NCTSSoS.moment_relax_symmetric(
+            pop,
+            sparsity.corr_sparsity,
+            sparsity.cliques_term_sparsities,
+            cfg.symmetry,
+        )
+
+        @test report.group_order == 2
+        @test sort(report.psd_block_sizes) == [1, 2]
+
+        _, (τx, τy, _) = create_pauli_variables(1:2)
+        xy_pair = 1.0 * (τx[1] * τx[2] + τy[1] * τy[2])
+        phase_spec = sympleq_symmetry_spec(xy_pair)
+        @test any(phase_spec.clifford_generators) do g
+            NCTSSoS._act_polynomial(g, xy_pair) == xy_pair &&
+                NCTSSoS._act_monomial(g, τx[1]) == (1, τy[1]) &&
+                NCTSSoS._act_monomial(g, τy[1]) == (-1, τx[1])
+        end
+    end
+
     @testset "symmetry helpers cover invariant constraints and scalar reductions" begin
         reg, (x,) = create_unipotent_variables([("x", 1:2)])
         invariant_poly = 1.0 * (x[1] + x[2])


### PR DESCRIPTION
## Summary
- add a SympleQ find-side pipeline for Pauli Hamiltonians: tableau construction, colored graph automorphisms, symplectic synthesis, and phase solving
- bridge recognized Clifford actions into the existing `CliffordSymmetry` / `SymmetrySpec` Pauli symmetry-reduction path
- add regressions showing `sympleq_symmetry_spec(H)` recognizes Pauli Hamiltonian symmetries and works with dense moment relaxation

## How to test
- `easy-ssh run "julia --project -e 'include(\"test/TestUtils.jl\"); include(\"test/Expectations.jl\"); using .TestExpectations: expectations_oracle; include(\"test/relaxations/symmetry.jl\")'"`\n  - Result on `HAI`: `Symmetry MVP Guards | 958  958  1m53.9s`\n- `easy-ssh run "julia --project -e 'using NCTSSoS; reg,(x,y,z)=create_pauli_variables(1:9); H=1.0*(x[1]+x[9]); spec=sympleq_symmetry_spec(H); @assert any(g -> NCTSSoS._act_polynomial(g,H)==H && NCTSSoS._act_monomial(g,x[1])==(1,x[9]) && NCTSSoS._act_monomial(g,x[9])==(1,x[1]), spec.clifford_generators); println(\"9-qubit SympleQ smoke ok: \" * string(length(spec.clifford_generators)) * \" generators\")'"`\n  - Result on `HAI`: `9-qubit SympleQ smoke ok: 5 generators`\n