### PR TITLE
perf: shrink polynomial term buffers + mirror-adapted DFT blocks for translation-invariant Pauli chains

### DIFF
--- a/perf/pauli_translation_invariant_scaling.jl
+++ b/perf/pauli_translation_invariant_scaling.jl
@@ -1,0 +1,46 @@
+#!/usr/bin/env julia
+
+# Structural scaling benchmark for the specialized translation-invariant
+# (momentum/DFT) Pauli-chain relaxation against the paper target of
+# Wang et al. arXiv:2604.01555v1:
+#   N=100, d=4, r=1 -> sparse basis size 12_001, max real PSD block <= 31.
+#
+# This does not call an SDP solver; it measures symbolic model construction.
+#
+# Usage:
+#   NCTS_PERF_NS=16,32,64,100 julia --project=. --startup-file=no perf/pauli_translation_invariant_scaling.jl
+#   NCTS_PERF_LEGACY=1 additionally measures reflection=false, conjugate_symmetry=false.
+
+using Printf
+using NCTSSoS
+
+function _run_one(n::Int, order::Int; reflection::Bool, conjugate_symmetry::Bool)
+    registry, ops = create_pauli_variables(1:n)
+    pop = polyopt(heisenberg_chain_hamiltonian(ops; coupling=1 / 4, periodic=true), registry)
+    GC.gc(true)
+    stats = @timed pauli_translation_invariant_moment_relaxation(
+        pop, ops, order; reflection, conjugate_symmetry
+    )
+    _, report = stats.value
+    @printf(
+        "| %d | %d | %s | %d | %d | %d | %d | %d | %.3f | %.3f |\n",
+        n, order, reflection && conjugate_symmetry ? "mirror+conj" : "legacy",
+        report.basis_size, report.orbit_basis_size,
+        length(report.psd_block_sizes), maximum(report.psd_block_sizes),
+        report.n_unique_moment_matrix_elements, stats.time, stats.bytes / 2^30,
+    )
+    flush(stdout)
+    return nothing
+end
+
+ns = [parse(Int, s) for s in split(get(ENV, "NCTS_PERF_NS", "16,32,64,100"), ",")]
+order = parse(Int, get(ENV, "NCTS_PERF_ORDER", "4"))
+legacy = get(ENV, "NCTS_PERF_LEGACY", "0") == "1"
+
+println("| N | d | rules | basis | orbit reps | blocks | max block | moments | time (s) | alloc (GiB) |")
+println("|--:|--:|:--|--:|--:|--:|--:|--:|--:|--:|")
+_run_one(4, min(order, 2); reflection=true, conjugate_symmetry=true)  # warmup
+for n in ns
+    legacy && _run_one(n, order; reflection=false, conjugate_symmetry=false)
+    _run_one(n, order; reflection=true, conjugate_symmetry=true)
+end

--- a/perf/ti_mosek_run.jl
+++ b/perf/ti_mosek_run.jl
@@ -1,0 +1,63 @@
+#!/usr/bin/env julia
+
+# Mosek-backed solve of the mirror-adapted translation-invariant (DFT) XXX
+# Heisenberg relaxation. Runs N=16 order 4 as a sanity anchor (COSMO
+# reference: -7.1443433630), then the paper-target N=100 order 4.
+#
+# Measured on 32 Mosek threads (Xeon, 128 cores):
+#   N=16  order=4 bound=-7.1443484721  OPTIMAL, 23.4 s
+#   N=100 order=4 bound=-44.4239941277 OPTIMAL, 1640.5 s, peak RSS ~270 GiB
+#
+# Env knobs: NCTS_MOSEK_THREADS (default cpu/4), NCTS_MOSEK_LOG (default 0).
+# Self-bootstraps a solver environment in ~/.nctssos_ti_mosek_env with this
+# checkout dev'ed, so it can run on a bare host via easy-ssh.
+
+using Pkg
+const REPO = dirname(@__DIR__)
+Pkg.activate(joinpath(homedir(), ".nctssos_ti_mosek_env"))
+Pkg.develop(path=REPO)
+Pkg.add(["MosekTools", "JuMP"])
+Pkg.instantiate()
+
+using NCTSSoS, JuMP, MosekTools, Printf, Dates
+using NCTSSoS: pauli_translation_invariant_nctssos, heisenberg_chain_hamiltonian,
+    create_pauli_variables, polyopt
+
+function mosek_optimizer()
+    threads = parse(Int, get(ENV, "NCTS_MOSEK_THREADS", string(max(1, div(Sys.CPU_THREADS, 4)))))
+    return optimizer_with_attributes(
+        Mosek.Optimizer,
+        "MSK_IPAR_LOG" => parse(Int, get(ENV, "NCTS_MOSEK_LOG", "0")),
+        "MSK_IPAR_NUM_THREADS" => threads,
+        "MSK_DPAR_INTPNT_CO_TOL_PFEAS" => 1e-8,
+        "MSK_DPAR_INTPNT_CO_TOL_DFEAS" => 1e-8,
+        "MSK_DPAR_INTPNT_CO_TOL_REL_GAP" => 1e-8,
+    )
+end
+
+function run_instance(n::Int, order::Int)
+    registry, ops = create_pauli_variables(1:n)
+    pop = polyopt(heisenberg_chain_hamiltonian(ops), registry)
+    GC.gc(true)
+    t0 = time()
+    res = pauli_translation_invariant_nctssos(pop, ops, order, mosek_optimizer(); dualize=true)
+    wall = time() - t0
+    @printf("RESULT N=%d order=%d bound=%.10f per_site=%.10f status=%s wall=%.1fs max_block=%d n_blocks=%d unique_moments=%d\n",
+        n, order, res.objective, res.objective / n,
+        string(termination_status(res.model)), wall,
+        maximum(res.report.psd_block_sizes), length(res.report.psd_block_sizes),
+        res.report.n_unique_moment_matrix_elements)
+    flush(stdout)
+    return res.objective
+end
+
+println("host=$(gethostname()) julia=$(VERSION) started=$(Dates.now())")
+println("threads=$(get(ENV, "NCTS_MOSEK_THREADS", "auto(cpu/4)")) cpu_threads=$(Sys.CPU_THREADS)")
+flush(stdout)
+
+b16 = run_instance(16, 4)
+@printf("SANITY N=16 |mosek - cosmo| = %.2e (cosmo ref -7.1443433630)\n", abs(b16 - (-7.1443433630)))
+flush(stdout)
+
+run_instance(100, 4)
+println("done=$(Dates.now())")

--- a/src/optimization/pauli_chains.jl
+++ b/src/optimization/pauli_chains.jl
@@ -365,6 +365,12 @@ mirror-even/odd blocks.  If `momenta` is supplied with
 `real_moment_matrix=false`, it must include sector `0` because the normalized
 identity moment lives there.
 
+`check_invariance=false` skips the translation *and* reflection invariance
+checks on the objective while the corresponding moment identifications are
+still applied, so it asserts that the caller has independently verified every
+enabled symmetry; passing a non-invariant objective with it produces an
+invalid relaxation.
+
 For the XXX chain with `N=100, order=4`, the default basis has 12,001 site-space
 monomials and the solver-facing real PSD blocks have side at most 31, matching
 the specialized construction of arXiv:2604.01555.

--- a/src/optimization/pauli_chains.jl
+++ b/src/optimization/pauli_chains.jl
@@ -293,6 +293,8 @@ struct TranslationInvariantReport
     orbit_basis_size::Int
     momentum_sectors::Vector{Int}
     sign_symmetry::Bool
+    reflection::Bool
+    conjugate_symmetry::Bool
     psd_block_sizes::Vector{Int}
     block_labels::Vector{Any}
     n_unique_moment_matrix_elements::Int
@@ -305,6 +307,7 @@ function Base.show(io::IO, report::TranslationInvariantReport)
         "TranslationInvariantReport(n_sites=$(report.n_sites), order=$(report.order), " *
         "basis_size=$(report.basis_size), orbit_basis_size=$(report.orbit_basis_size), " *
         "momentum_sectors=$(report.momentum_sectors), sign_symmetry=$(report.sign_symmetry), " *
+        "reflection=$(report.reflection), conjugate_symmetry=$(report.conjugate_symmetry), " *
         "psd_block_sizes=$(report.psd_block_sizes), " *
         "n_unique_moment_matrix_elements=$(report.n_unique_moment_matrix_elements), " *
         "real_moment_matrix=$(report.real_moment_matrix))"
@@ -339,20 +342,32 @@ This is an intentionally narrow large-spin-chain path:
 - ordinary unconstrained `PauliAlgebra` polynomial objectives only;
 - periodic translation by one site on the declared chain `1:N`;
 - a contiguous local half-basis from [`pauli_contiguous_chain_basis`](@ref);
-- optional `(ℤ₂)^2` Heisenberg sign-symmetry splitting, enabled by default.
+- optional `(ℤ₂)^2` Heisenberg sign-symmetry splitting, enabled by default;
+- optional mirror (`reflection`) and conjugation (`conjugate_symmetry`) moment
+  replacement rules, both enabled by default.
 
-By default this builds the paper-style real primal moment matrix: complex
-momentum blocks are realified once, conjugate momenta are not duplicated, and
-moment variables are real.  Set `real_moment_matrix=false` only for debugging the
-older complex Hermitian block form.
+By default this builds the paper-style real primal moment matrix: conjugate
+momenta are not duplicated and moment variables are real.  Set
+`real_moment_matrix=false` only for debugging the older complex Hermitian
+block form.
 
 When `sign_symmetry=true`, the objective must be invariant under the global
-Heisenberg sign flips.  If `momenta` is supplied with `real_moment_matrix=false`,
-it must include sector `0` because the normalized identity moment lives there.
+Heisenberg sign flips.  When `reflection=true`, the objective must be invariant
+under the mirror `site i ↦ N + 1 - i` and the basis must be mirror-closed;
+moments are then identified over dihedral (translation + mirror) orbits.  When
+`conjugate_symmetry=true`, every objective term must have a real coefficient and
+an even number of σʸ letters; moments of monomials with an odd σʸ count are then
+identically zero and are dropped.  With both rules and `real_moment_matrix=true`,
+each complex momentum block is rotated by an explicit phase-adapted mirror
+transform into an exactly real PSD block of the same side (instead of the
+doubled realified side), and the `k = 0` sector additionally splits into
+mirror-even/odd blocks.  If `momenta` is supplied with
+`real_moment_matrix=false`, it must include sector `0` because the normalized
+identity moment lives there.
 
 For the XXX chain with `N=100, order=4`, the default basis has 12,001 site-space
-monomials; the logical complex momentum blocks have side at most 31 and the
-solver-facing real PSD blocks have side at most 62.
+monomials and the solver-facing real PSD blocks have side at most 31, matching
+the specialized construction of arXiv:2604.01555.
 """
 function pauli_translation_invariant_moment_relaxation(
     pop::PolyOpt{PauliAlgebra,T,P},
@@ -361,6 +376,8 @@ function pauli_translation_invariant_moment_relaxation(
     basis::Union{Nothing,Vector{NormalMonomial{PauliAlgebra,T}}}=nothing,
     momenta::Union{Nothing,AbstractVector{<:Integer}}=nothing,
     sign_symmetry::Bool=true,
+    reflection::Bool=true,
+    conjugate_symmetry::Bool=true,
     check_invariance::Bool=true,
     real_moment_matrix::Bool=true,
     phase_atol::Real=1e-12,
@@ -384,7 +401,10 @@ function pauli_translation_invariant_moment_relaxation(
     check_invariance && _check_translation_invariance(pop.objective, n)
     sign_symmetry && _check_pauli_sign_invariance(pop.objective)
     real_moment_matrix && _check_real_pauli_chain_objective(pop.objective)
+    reflection && check_invariance && _check_reflection_invariance(pop.objective, n)
+    conjugate_symmetry && _check_conjugate_invariant_objective(pop.objective)
     _check_translation_basis_closure(local_basis, n)
+    reflection && _check_reflection_basis_closure(local_basis, n)
 
     orbit_reps = _translation_orbit_representatives(local_basis, n)
     nontrivial_reps = [m for m in orbit_reps if !isone(m)]
@@ -395,7 +415,11 @@ function pauli_translation_invariant_moment_relaxation(
     MP_C = Complex{MP_R}
     MP_P = Polynomial{PauliAlgebra,T,real_moment_matrix ? MP_R : MP_C}
     BLOCK_P = Polynomial{PauliAlgebra,T,MP_C}
-    objective_mp = convert(MP_P, _translation_orbit_reduce_polynomial(pop.objective, n))
+    reducer = _PauliMomentReducer{NormalMonomial{PauliAlgebra,T}}(n, reflection, conjugate_symmetry)
+    objective_mp = convert(MP_P, _reduce_moment_polynomial(pop.objective, reducer))
+
+    mirror_transform = reflection && conjugate_symmetry && real_moment_matrix
+    pairing = reflection ? _mirror_pairing(orbit_reps, n) : nothing
 
     translated = Dict{NormalMonomial{PauliAlgebra,T},Vector{NormalMonomial{PauliAlgebra,T}}}()
     for rep in nontrivial_reps
@@ -403,7 +427,6 @@ function pauli_translation_invariant_moment_relaxation(
     end
     translated[one_mono] = fill(one_mono, n)
 
-    rep_cache = Dict{NormalMonomial{PauliAlgebra,T},NormalMonomial{PauliAlgebra,T}}()
     constraints = Tuple{Symbol,Matrix{MP_P}}[]
     moment_terms = NormalMonomial{PauliAlgebra,T}[]
     block_sizes = Int[]
@@ -414,15 +437,28 @@ function pauli_translation_invariant_moment_relaxation(
         blocks = sign_symmetry ? _pauli_signature_blocks(sector_basis) : [(:all, sector_basis)]
         for (signature, block_basis) in blocks
             isempty(block_basis) && continue
-            complex_mat = _translation_momentum_block(block_basis, k, n, translated, rep_cache, BLOCK_P)
-            cone, mat = real_moment_matrix ?
-                (:PSD, _realify_hermitian_block(complex_mat, MP_P; atol=MP_R(phase_atol))) :
-                (:HPSD, map(p -> convert(MP_P, p), complex_mat))
-            push!(constraints, (cone, mat))
-            push!(block_sizes, size(mat, 1))
-            push!(block_labels, (momentum=k, signature=signature))
-            for entry in mat
-                append!(moment_terms, monomials(entry))
+            complex_mat = _translation_momentum_block(block_basis, k, n, translated, reducer, BLOCK_P)
+            if mirror_transform
+                for (parity, mat) in _mirror_real_blocks(complex_mat, block_basis, pairing, k, n, MP_P; atol=MP_R(phase_atol))
+                    push!(constraints, (:PSD, mat))
+                    push!(block_sizes, size(mat, 1))
+                    label = parity === :none ? (momentum=k, signature=signature) :
+                        (momentum=k, signature=signature, parity=parity)
+                    push!(block_labels, label)
+                    for entry in mat
+                        append!(moment_terms, monomials(entry))
+                    end
+                end
+            else
+                cone, mat = real_moment_matrix ?
+                    (:PSD, _realify_hermitian_block(complex_mat, MP_P; atol=MP_R(phase_atol))) :
+                    (:HPSD, map(p -> convert(MP_P, p), complex_mat))
+                push!(constraints, (cone, mat))
+                push!(block_sizes, size(mat, 1))
+                push!(block_labels, (momentum=k, signature=signature))
+                for entry in mat
+                    append!(moment_terms, monomials(entry))
+                end
             end
         end
     end
@@ -447,6 +483,8 @@ function pauli_translation_invariant_moment_relaxation(
         length(orbit_reps),
         sectors,
         sign_symmetry,
+        reflection,
+        conjugate_symmetry,
         block_sizes,
         block_labels,
         n_unique,
@@ -674,20 +712,147 @@ function _check_translation_invariance(poly::Polynomial{PauliAlgebra,T,C}, n_sit
     return nothing
 end
 
-function _translation_orbit_reduce_polynomial(
-    poly::Polynomial{PauliAlgebra,T,C},
+"""
+    _reflect_pauli_monomial(mono, n_sites)
+
+Apply the chain mirror `site i ↦ n_sites + 1 - i` to a normal-form Pauli word.
+Site permutations of normal words never produce a phase because all letters
+live on distinct sites.
+"""
+function _reflect_pauli_monomial(
+    mono::NormalMonomial{PauliAlgebra,T},
     n_sites::Integer,
+) where {T<:Unsigned}
+    isempty(mono.word) && return mono
+    n = Int(n_sites)
+    word = Vector{T}(undef, length(mono.word))
+    for (i, idx) in pairs(mono.word)
+        site = _pauli_site(idx)
+        ptype = _pauli_type(idx)
+        word[i] = _pauli_index_from_site_type(T, n + 1 - site, ptype)
+    end
+    simplified, phase = simplify(PauliAlgebra, word)
+    phase == 0x00 || throw(ArgumentError("Internal error: Pauli reflection produced phase $phase."))
+    return NormalMonomial{PauliAlgebra,T}(copy(simplified))
+end
+
+_pauli_y_count(mono::NormalMonomial{PauliAlgebra}) =
+    count(idx -> _pauli_type(idx) == _PAULI_Y_TYPE, mono.word)
+
+"""
+    _PauliMomentReducer
+
+Reduces monomials appearing in moment-matrix entries to canonical moment
+representatives: translation-orbit representatives, optionally identified over
+mirror images (`reflection`), with moments of odd σʸ count dropped as
+identically zero (`drop_odd_y`, valid under conjugation symmetry).
+"""
+struct _PauliMomentReducer{M<:NormalMonomial{PauliAlgebra}}
+    n::Int
+    reflection::Bool
+    drop_odd_y::Bool
+    cache::Dict{M,Union{M,Nothing}}
+end
+
+function _PauliMomentReducer{M}(n::Integer, reflection::Bool, drop_odd_y::Bool) where {M}
+    return _PauliMomentReducer{M}(Int(n), reflection, drop_odd_y, Dict{M,Union{M,Nothing}}())
+end
+
+function _reduce_moment(reducer::_PauliMomentReducer{M}, mono::M) where {M}
+    return get!(reducer.cache, mono) do
+        reducer.drop_odd_y && isodd(_pauli_y_count(mono)) && return nothing
+        rep = _translation_orbit_representative(mono, reducer.n)
+        if reducer.reflection
+            alt = _translation_orbit_representative(
+                _reflect_pauli_monomial(mono, reducer.n), reducer.n
+            )
+            alt < rep && (rep = alt)
+        end
+        return rep
+    end
+end
+
+function _reduce_moment_polynomial(
+    poly::Polynomial{PauliAlgebra,T,C},
+    reducer::_PauliMomentReducer{NormalMonomial{PauliAlgebra,T}},
 ) where {T<:Unsigned,C<:Number}
     terms = Tuple{C,NormalMonomial{PauliAlgebra,T}}[]
     sizehint!(terms, length(poly.terms))
-    cache = Dict{NormalMonomial{PauliAlgebra,T},NormalMonomial{PauliAlgebra,T}}()
     for (coef, mono) in poly.terms
-        rep = get!(cache, mono) do
-            _translation_orbit_representative(mono, n_sites)
-        end
+        rep = _reduce_moment(reducer, mono)
+        rep === nothing && continue
         push!(terms, (coef, rep))
     end
     return Polynomial(terms)
+end
+
+"""
+    _mirror_pairing(reps, n_sites)
+
+For each translation-orbit representative `a`, find the representative `â` of
+its mirror image and the shift `s` with `ω(a) = T^s(â)`.  The map `a ↦ â` is an
+involution with matching shifts (`s_â = s_a`).
+"""
+function _mirror_pairing(
+    reps::Vector{M},
+    n_sites::Integer,
+) where {M<:NormalMonomial{PauliAlgebra}}
+    n = Int(n_sites)
+    partner = Dict{M,M}()
+    shift = Dict{M,Int}()
+    for a in reps
+        image = _reflect_pauli_monomial(a, n)
+        ahat = _translation_orbit_representative(image, n)
+        s = -1
+        for r in 0:(n - 1)
+            if _translate_pauli_monomial(ahat, r, n) == image
+                s = r
+                break
+            end
+        end
+        s >= 0 || throw(ArgumentError("Internal error: mirror image of $a is not a translate of its orbit representative."))
+        partner[a] = ahat
+        shift[a] = s
+    end
+    return (partner=partner, shift=shift)
+end
+
+function _check_reflection_invariance(
+    poly::Polynomial{PauliAlgebra,T,C},
+    n_sites::Integer,
+) where {T<:Unsigned,C<:Number}
+    n = Int(n_sites)
+    reflected = Polynomial([(coef, _reflect_pauli_monomial(mono, n)) for (coef, mono) in poly.terms])
+    reflected == poly || throw(ArgumentError(
+        "reflection=true requires the objective to be invariant under the chain mirror site i ↦ $(n) + 1 - i. Pass reflection=false for non-invariant objectives."
+    ))
+    return nothing
+end
+
+function _check_reflection_basis_closure(
+    basis::Vector{NormalMonomial{PauliAlgebra,T}},
+    n_sites::Integer,
+) where {T<:Unsigned}
+    basis_set = Set(basis)
+    for mono in basis
+        image = _reflect_pauli_monomial(mono, n_sites)
+        image in basis_set || throw(ArgumentError(
+            "reflection=true requires a mirror-closed basis; $mono maps to $image outside the basis. Pass reflection=false or supply a mirror-closed basis."
+        ))
+    end
+    return nothing
+end
+
+function _check_conjugate_invariant_objective(
+    poly::Polynomial{PauliAlgebra,T,C},
+) where {T<:Unsigned,C<:Number}
+    for (coef, mono) in poly.terms
+        iszero(coef) && continue
+        (iszero(imag(coef)) && iseven(_pauli_y_count(mono))) || throw(ArgumentError(
+            "conjugate_symmetry=true requires a conjugation-invariant objective (real coefficients and an even number of σʸ letters per term); term $mono with coefficient $coef violates this. Pass conjugate_symmetry=false."
+        ))
+    end
+    return nothing
 end
 
 function _check_pauli_sign_invariance(poly::Polynomial{PauliAlgebra,T,C}) where {T<:Unsigned,C<:Number}
@@ -761,7 +926,7 @@ function _translation_momentum_entry(
     k::Int,
     n::Int,
     translated::Dict{M,Vector{M}},
-    rep_cache::Dict{M,M},
+    reducer::_PauliMomentReducer{M},
     ::Type{P},
 ) where {T<:Unsigned,M<:NormalMonomial{PauliAlgebra,T},P<:Polynomial{PauliAlgebra,T}}
     if isone(row) && isone(col)
@@ -778,9 +943,8 @@ function _translation_momentum_entry(
         phase = C(_momentum_phase(R, k, r, n))
         prod = row * col_translates[r + 1]
         for (coef, mono) in prod.terms
-            rep = get!(rep_cache, mono) do
-                _translation_orbit_representative(mono, n)
-            end
+            rep = _reduce_moment(reducer, mono)
+            rep === nothing && continue
             push!(terms, (cross_scale * phase * C(coef), rep))
         end
     end
@@ -849,18 +1013,145 @@ function _realify_hermitian_block(
     return realified
 end
 
+"""
+    _mirror_columns(block_basis, pairing, k, n_sites, CT)
+
+Build the columns of the phase-adapted mirror transform `W` for momentum
+sector `k`.  Each orbit representative `a` receives the phase
+`exp(i·(π k s_a / n + π y_a / 2))` where `s_a` is its mirror shift and `y_a`
+its σʸ count; mirror pairs additionally combine into even (`(u_a + u_â)/√2`)
+and odd (`i(u_a - u_â)/√2`) columns.  `W` is unitary and `W' M_k W` is exactly
+real under dihedral moment identification with odd-σʸ moments dropped.
+"""
+function _mirror_columns(
+    block_basis::Vector{M},
+    pairing,
+    k::Int,
+    n_sites::Int,
+    ::Type{CT},
+) where {M<:NormalMonomial{PauliAlgebra},CT<:Complex}
+    R = typeof(real(one(CT)))
+    index = Dict{M,Int}(mono => i for (i, mono) in enumerate(block_basis))
+    cols_even = Vector{Vector{Tuple{Int,CT}}}()
+    cols_odd = Vector{Vector{Tuple{Int,CT}}}()
+    paired = falses(length(block_basis))
+    for (i, a) in enumerate(block_basis)
+        paired[i] && continue
+        paired[i] = true
+        ahat = pairing.partner[a]
+        s = pairing.shift[a]
+        α = R(pi) * R(k) * R(s) / R(n_sites) + R(pi) / 2 * R(_pauli_y_count(a))
+        c = CT(cis(α))
+        if ahat == a
+            push!(cols_even, [(i, c)])
+        else
+            j = get(index, ahat, 0)
+            j > 0 || throw(ArgumentError("Internal error: mirror partner $ahat of $a is missing from its momentum block."))
+            paired[j] = true
+            scale = CT(inv(sqrt(R(2))))
+            push!(cols_even, [(i, c * scale), (j, c * scale)])
+            push!(cols_odd, [(i, im * c * scale), (j, -im * c * scale)])
+        end
+    end
+    return cols_even, cols_odd
+end
+
+function _mirror_transformed_entry(
+    mat::Matrix{P},
+    ci::Vector{Tuple{Int,CT}},
+    cj::Vector{Tuple{Int,CT}},
+) where {P<:Polynomial,CT<:Complex}
+    acc = nothing
+    for (p, cp) in ci, (q, cq) in cj
+        contrib = (conj(cp) * cq) * mat[p, q]
+        acc = acc === nothing ? contrib : acc + contrib
+    end
+    return acc::P
+end
+
+function _mirror_transformed_block(
+    mat::Matrix{PC},
+    cols::Vector{Vector{Tuple{Int,CT}}},
+    ::Type{PReal};
+    atol,
+) where {PC<:Polynomial,CT<:Complex,PReal<:Polynomial}
+    m = length(cols)
+    out = Matrix{PReal}(undef, m, m)
+    for j in 1:m, i in 1:j
+        entry = _mirror_transformed_entry(mat, cols[i], cols[j])
+        imag_entry = _imag_part_polynomial(entry, PReal; atol)
+        iszero(imag_entry) || throw(ArgumentError(
+            "Internal error: mirror-adapted momentum block has a non-real entry; residual imaginary part $(imag_entry)."
+        ))
+        re = _real_part_polynomial(entry, PReal; atol)
+        out[i, j] = re
+        i == j || (out[j, i] = re)
+    end
+    return out
+end
+
+function _assert_mirror_zero_cross(
+    mat::Matrix{PC},
+    cols_even::Vector{Vector{Tuple{Int,CT}}},
+    cols_odd::Vector{Vector{Tuple{Int,CT}}},
+    ::Type{PReal};
+    atol,
+) where {PC<:Polynomial,CT<:Complex,PReal<:Polynomial}
+    for ce in cols_even, co in cols_odd
+        entry = _mirror_transformed_entry(mat, ce, co)
+        re = _real_part_polynomial(entry, PReal; atol)
+        imag_entry = _imag_part_polynomial(entry, PReal; atol)
+        (iszero(re) && iszero(imag_entry)) || throw(ArgumentError(
+            "Internal error: mirror-adapted k = 0 block has a nonzero even/odd cross entry $(re + imag_entry)."
+        ))
+    end
+    return nothing
+end
+
+"""
+    _mirror_real_blocks(complex_mat, block_basis, pairing, k, n_sites, PReal; atol)
+
+Rotate a complex Hermitian momentum block into exactly real PSD blocks using
+the phase-adapted mirror transform.  For `k = 0` the block splits into
+mirror-even and mirror-odd sub-blocks (their cross entries vanish and are
+asserted to); all other sectors yield a single real block of the same side.
+"""
+function _mirror_real_blocks(
+    complex_mat::Matrix{PC},
+    block_basis::Vector{M},
+    pairing,
+    k::Int,
+    n_sites::Int,
+    ::Type{PReal};
+    atol,
+) where {PC<:Polynomial,M<:NormalMonomial{PauliAlgebra},PReal<:Polynomial}
+    CT = _coefficient_type(PC)
+    cols_even, cols_odd = _mirror_columns(block_basis, pairing, k, n_sites, CT)
+    if k == 0
+        blocks = Tuple{Symbol,Matrix{PReal}}[]
+        isempty(cols_even) || push!(blocks, (:even, _mirror_transformed_block(complex_mat, cols_even, PReal; atol)))
+        if !isempty(cols_odd)
+            push!(blocks, (:odd, _mirror_transformed_block(complex_mat, cols_odd, PReal; atol)))
+            _assert_mirror_zero_cross(complex_mat, cols_even, cols_odd, PReal; atol)
+        end
+        return blocks
+    end
+    cols = vcat(cols_even, cols_odd)
+    return Tuple{Symbol,Matrix{PReal}}[(:none, _mirror_transformed_block(complex_mat, cols, PReal; atol))]
+end
+
 function _translation_momentum_block(
     block_basis::Vector{M},
     k::Int,
     n::Int,
     translated::Dict{M,Vector{M}},
-    rep_cache::Dict{M,M},
+    reducer::_PauliMomentReducer{M},
     ::Type{P},
 ) where {T<:Unsigned,M<:NormalMonomial{PauliAlgebra,T},P<:Polynomial{PauliAlgebra,T}}
     m = length(block_basis)
     mat = Matrix{P}(undef, m, m)
     for j in 1:m, i in 1:j
-        entry = _translation_momentum_entry(block_basis[i], block_basis[j], k, n, translated, rep_cache, P)
+        entry = _translation_momentum_entry(block_basis[i], block_basis[j], k, n, translated, reducer, P)
         if i == j
             mat[i, i] = (entry + adjoint(entry)) / 2
         else

--- a/src/optimization/symmetry.jl
+++ b/src/optimization/symmetry.jl
@@ -2260,7 +2260,7 @@ end
     atol::Float64=_SYMMETRY_ATOL,
 ) where {A<:AlgebraType,T<:Integer,C<:Number}
     terms = _process_terms!(owned_terms, C)
-    isempty(terms) && return _unchecked_polynomial(terms)
+    isempty(terms) && return _unchecked_polynomial(_shrink_terms!(terms))
 
     write_idx = 0
     @inbounds for idx in eachindex(terms)
@@ -2271,7 +2271,7 @@ end
         end
     end
     resize!(terms, write_idx)
-    return _unchecked_polynomial(terms)
+    return _unchecked_polynomial(_shrink_terms!(terms))
 end
 
 @inline function _push_transformed_polynomial_terms!(

--- a/src/types/polynomial.jl
+++ b/src/types/polynomial.jl
@@ -178,10 +178,27 @@ end
     return Polynomial{A,T,C}(owned_terms, Val(:trusted))
 end
 
+"""
+    _shrink_terms!(terms::Vector) -> Vector
+
+Shrink the backing capacity of an owned term buffer to its current length.
+
+Owned buffers are typically `sizehint!`-ed for worst-case term counts (e.g.
+products of support sizes) before canonicalization combines and drops most
+terms. A polynomial that takes ownership of such a buffer would otherwise
+retain the full worst-case capacity for its lifetime; in large moment
+relaxations this overcapacity dominates resident memory. `sizehint!` only
+reallocates when the saving is significant, so exact-sized buffers are a no-op.
+"""
+@inline function _shrink_terms!(terms::Vector)
+    sizehint!(terms, length(terms); shrink=true)
+    return terms
+end
+
 @inline function _polynomial_from_owned_terms!(
     owned_terms::Vector{Tuple{C,NormalMonomial{A,T}}}
 ) where {A<:AlgebraType,T<:Integer,C<:Number}
-    return _unchecked_polynomial(_process_terms!(owned_terms, C))
+    return _unchecked_polynomial(_shrink_terms!(_process_terms!(owned_terms, C)))
 end
 
 # =============================================================================

--- a/test/polynomials/performance_paths.jl
+++ b/test/polynomials/performance_paths.jl
@@ -224,4 +224,43 @@ end
         @test f != b
         @test hash(f, seed1) != hash(b, seed1)
     end
+
+    @testset "Owned term buffers are shrunk to fit" begin
+        # Regression: owned buffers sizehint!-ed for worst-case term counts
+        # must not be retained at full capacity by the resulting polynomial.
+        # Before the fix, each retained polynomial kept its worst-case backing
+        # Memory (e.g. |left|x|right| slots in symmetry transforms), which
+        # dominated resident memory of large moment relaxations.
+        M = NormalMonomial{NonCommutativeAlgebra,UInt16}
+        m1 = M(nc_word(1))
+        m2 = M(nc_word(1, 2))
+
+        worst_case_capacity = 100_000
+        # ~24 bytes/slot; well below the ~2.4 MB a retained worst-case buffer costs.
+        shrunk_budget = 10_000
+
+        buffered = Tuple{Float64,M}[]
+        sizehint!(buffered, worst_case_capacity)
+        push!(buffered, (1.0, m1))
+        push!(buffered, (-1.0, m1))  # cancels during canonicalization
+        push!(buffered, (2.0, m2))
+        p = NCTSSoS._polynomial_from_owned_terms!(buffered)
+        @test coefficients(p) == [2.0]
+        @test Base.summarysize(p.terms) < shrunk_budget
+
+        chop_buffered = Tuple{Float64,M}[]
+        sizehint!(chop_buffered, worst_case_capacity)
+        push!(chop_buffered, (1e-12, m1))  # below default atol, chopped
+        push!(chop_buffered, (3.0, m2))
+        pc = NCTSSoS._polynomial_from_owned_terms_chopped!(chop_buffered)
+        @test coefficients(pc) == [3.0]
+        @test Base.summarysize(pc.terms) < shrunk_budget
+
+        empty_buffered = Tuple{Float64,M}[]
+        sizehint!(empty_buffered, worst_case_capacity)
+        push!(empty_buffered, (1e-12, m1))
+        pe = NCTSSoS._polynomial_from_owned_terms_chopped!(empty_buffered)
+        @test iszero(pe)
+        @test Base.summarysize(pe.terms) < shrunk_budget
+    end
 end

--- a/test/relaxations/pauli_chains.jl
+++ b/test/relaxations/pauli_chains.jl
@@ -137,8 +137,16 @@ end
         mp, report = pauli_translation_invariant_moment_relaxation(pop, ops, 1; sign_symmetry=false)
         identity_cross = mp.constraints[1][2][1, 2]
         @test only(coefficients(identity_cross)) ≈ sqrt(n) + 0im atol = 1e-12
-        @test report.psd_block_sizes == [8, 6, 6]
+        @test report.psd_block_sizes == [4, 3, 3]
+        @test report.block_labels[1] == (momentum=0, signature=:all, parity=:even)
         @test report.real_moment_matrix
+        @test report.reflection
+        @test report.conjugate_symmetry
+
+        _, report_legacy = pauli_translation_invariant_moment_relaxation(
+            pop, ops, 1; sign_symmetry=false, reflection=false, conjugate_symmetry=false
+        )
+        @test report_legacy.psd_block_sizes == [8, 6, 6]
 
         n_large = 20
         registry_large, ops_large = create_pauli_variables(1:n_large)
@@ -147,8 +155,15 @@ end
 
         @test report_large.basis_size == 1 + n_large * sum(3^ℓ for ℓ in 1:4)
         @test report_large.orbit_basis_size == 1 + sum(3^ℓ for ℓ in 1:4)
-        @test maximum(report_large.psd_block_sizes) == 62
-        @test length(report_large.psd_block_sizes) == 4 * (fld(n_large, 2) + 1)
+        @test maximum(report_large.psd_block_sizes) == 30
+        @test length(report_large.psd_block_sizes) == 4 * (fld(n_large, 2) + 1) + 4
+
+        _, report_large_legacy = pauli_translation_invariant_moment_relaxation(
+            pop_large, ops_large, 4; reflection=false, conjugate_symmetry=false
+        )
+        @test maximum(report_large_legacy.psd_block_sizes) == 62
+        @test report_large.n_unique_moment_matrix_elements <
+              report_large_legacy.n_unique_moment_matrix_elements
     end
 
     @testset "guardrails reject invalid reductions" begin
@@ -160,7 +175,20 @@ end
 
         field_pop = polyopt(sum(ops[1]), registry)
         @test_throws ArgumentError pauli_translation_invariant_moment_relaxation(field_pop, ops, 1)
-        @test pauli_translation_invariant_moment_relaxation(field_pop, ops, 1; sign_symmetry=false)[2].psd_block_sizes == [8, 6, 6]
+        @test pauli_translation_invariant_moment_relaxation(field_pop, ops, 1; sign_symmetry=false)[2].psd_block_sizes == [4, 3, 3]
+
+        y_field_pop = polyopt(sum(ops[2]), registry)
+        @test_throws ArgumentError pauli_translation_invariant_moment_relaxation(y_field_pop, ops, 1; sign_symmetry=false)
+        @test pauli_translation_invariant_moment_relaxation(
+            y_field_pop, ops, 1; sign_symmetry=false, conjugate_symmetry=false, reflection=false
+        )[2].psd_block_sizes == [8, 6, 6]
+
+        σx4, _, σz4 = ops
+        chiral_pop = polyopt(sum(σx4[i] * σz4[mod1(i + 1, 4)] for i in 1:4), registry)
+        @test_throws ArgumentError pauli_translation_invariant_moment_relaxation(chiral_pop, ops, 1; sign_symmetry=false)
+        @test pauli_translation_invariant_moment_relaxation(
+            chiral_pop, ops, 1; sign_symmetry=false, reflection=false, conjugate_symmetry=false
+        )[2].psd_block_sizes == [8, 6, 6]
 
         σx, σy, σz = ops
         @test_throws ArgumentError pauli_contiguous_chain_basis((σy, σx, σz), 1)
@@ -190,5 +218,30 @@ end
         @test termination_status(reduced.model) == JuMP.MOI.OPTIMAL
         @test reduced.objective ≈ dense.objective atol = 1e-6
         @test maximum(reduced.report.psd_block_sizes) < only(flatten_sizes(dense.moment_matrix_sizes))
+    end
+
+    @testset "mirror/conjugate rules tighten monotonically and stay valid" begin
+        n = 6
+        registry, ops = create_pauli_variables(1:n)
+        pop = polyopt(heisenberg_chain_hamiltonian(ops), registry)
+
+        legacy = quiet() do
+            pauli_translation_invariant_nctssos(
+                pop, ops, 2, SOLVER; dualize=false, reflection=false, conjugate_symmetry=false
+            )
+        end
+        mirrored = quiet() do
+            pauli_translation_invariant_nctssos(pop, ops, 2, SOLVER; dualize=false)
+        end
+
+        @test termination_status(legacy.model) == JuMP.MOI.OPTIMAL
+        @test termination_status(mirrored.model) == JuMP.MOI.OPTIMAL
+        # Moment replacement rules add valid constraints: the bound may only tighten,
+        # and must stay below the exact N=6 XXX ground energy (-2.802775637...).
+        @test mirrored.objective >= legacy.objective - 1e-6
+        @test mirrored.objective <= -2.802775637 + 1e-4
+        @test maximum(mirrored.report.psd_block_sizes) < maximum(legacy.report.psd_block_sizes)
+        @test mirrored.report.n_unique_moment_matrix_elements <
+              legacy.report.n_unique_moment_matrix_elements
     end
 end


### PR DESCRIPTION
## Summary

Three commits addressing the two dominant scaling costs identified while profiling the sparse Heisenberg d4 workload:

### 1. `4c4fa16` — shrink owned term buffers after canonicalization

Symmetry transforms reserve worst-case product capacity in polynomial term vectors; canonicalization shortened them without releasing the backing memory. Adds `_shrink_terms!` (`sizehint!(...; shrink=true)`) after canonicalization/chopping, plus a regression test that a 100k-capacity term vector is not retained.

Measured on the `perf/heisenberg_mosek_scaling.jl` sparse d4 structural path:

| workload | `summarysize(mp.constraints)` | peak HWM |
|---|---:|---:|
| N=12 | 2.814 GiB → 0.077 GiB | 5.83 → 3.13 GiB |
| N=16 | 1.556 GiB → 0.033 GiB | 4.11 → 2.59 GiB |

### 2. `67c146c` — mirror-adapted DFT blocks

Adds `reflection=true` and `conjugate_symmetry=true` moment replacement rules to `pauli_translation_invariant_moment_relaxation` (opt-out kwargs restore the previous translation-only behavior):

- moments identified over dihedral (translation + mirror) orbits;
- moments with an odd σʸ count dropped as identically zero;
- each complex momentum block rotated by a phase-adapted mirror transform `exp(i(π k s_a/N + π y_a/2))` into an exactly real PSD block of the **same** side instead of the doubled realified side; the k=0 sector further splits into mirror-even/odd blocks;
- guardrails reject non-mirror-invariant objectives, non-mirror-closed bases, and conjugation-violating objectives; block reality is asserted symbolically, not tolerance-chopped.

For the XXX chain at N=100, order 4, the max solver-facing PSD block drops **62 → 30** (paper target 31, arXiv:2604.01555). Adds `perf/pauli_translation_invariant_scaling.jl` (`NCTS_PERF_NS`, `NCTS_PERF_LEGACY` env knobs):

| N | basis | max block | time | alloc |
|---:|---:|---:|---:|---:|
| 16 | 1,921 | 30 | 0.41 s | 0.29 GiB |
| 100 | 12,001 | 30 | 48.3 s | 13.5 GiB |

### 3. `8d4ec1f` — document `check_invariance=false` as unsafe

Audit follow-up: the flag skips the translation/reflection invariance checks while the moment identifications still apply, so it now carries an explicit warning.

## Verification

- Full test suite: **6760 pass, 2 broken (pre-existing)**, 17m59s.
- Numeric harness: for N ∈ {4,5,6,7,9,12}, all 124 momentum/signature blocks have square unitary W and each real output block equals W′MW under random real moment assignments.
- Exactness: N=4 order-2 mirrored bound = −1.999999999998776 vs exact XXX ground energy −2 (COSMO, OPTIMAL).
- Monotone tightening vs the legacy translation-only path at N=5/6/7; N=6 order-2 bound stays below the exact ground energy.
- Independent adversarial review found no validity bugs (conjugation-averaging and dihedral moment identification confirmed valid; phase lift ambiguity is a harmless column sign).