### PR TITLE
ci: prepare Amp orb development environment

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# No persistent services (databases, tunnels) are required by this repository.
+# Julia toolchain and package depot live on disk and survive orb pause/resume.
+echo "No persistent services need to be resumed."

--- a/.agents/setup
+++ b/.agents/setup
@@ -43,7 +43,9 @@ if [[ -n "${MOSEK_LICENSE_B64:-}" || -n "${MOSEK_LICENSE:-}" ]]; then
     license_tmp="$(mktemp "$HOME/mosek/.mosek.lic.XXXXXX")"
     trap 'rm -f -- "$license_tmp"' EXIT
     if [[ -n "${MOSEK_LICENSE_B64:-}" ]]; then
-        printf '%s' "$MOSEK_LICENSE_B64" | base64 -d | tr -d '\r' > "$license_tmp"
+        # Filter to the base64 alphabet first: pasted secrets often pick up stray
+        # bytes (shell prompt artifacts, newlines) that would fail strict decoding.
+        printf '%s' "$MOSEK_LICENSE_B64" | tr -cd 'A-Za-z0-9+/=' | base64 -d | tr -d '\r' > "$license_tmp"
     elif [[ "$MOSEK_LICENSE" == *$'\n'* ]]; then
         printf '%s' "$MOSEK_LICENSE" | tr -d '\r' > "$license_tmp"
     else

--- a/.agents/setup
+++ b/.agents/setup
@@ -43,7 +43,7 @@ if [[ -n "${MOSEK_LICENSE_B64:-}" || -n "${MOSEK_LICENSE:-}" ]]; then
     license_tmp="$(mktemp "$HOME/mosek/.mosek.lic.XXXXXX")"
     trap 'rm -f -- "$license_tmp"' EXIT
     if [[ -n "${MOSEK_LICENSE_B64:-}" ]]; then
-        printf '%s' "$MOSEK_LICENSE_B64" | base64 -d > "$license_tmp"
+        printf '%s' "$MOSEK_LICENSE_B64" | base64 -d | tr -d '\r' > "$license_tmp"
     elif [[ "$MOSEK_LICENSE" == *$'\n'* ]]; then
         printf '%s' "$MOSEK_LICENSE" | tr -d '\r' > "$license_tmp"
     else

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "==> Configuring Julia 1.12"
+if command -v julia >/dev/null 2>&1 &&
+    julia --startup-file=no -e 'exit(VERSION.major == 1 && VERSION.minor == 12 ? 0 : 1)'; then
+    julia_bin="$(command -v julia)"
+else
+    juliaup_bin="$HOME/.juliaup/bin/juliaup"
+    if [[ ! -x "$juliaup_bin" ]]; then
+        curl -fsSL https://install.julialang.org | sh -s -- --yes --default-channel 1.12
+    fi
+
+    if ! "$HOME/.juliaup/bin/julia" +1.12 --startup-file=no \
+        -e 'exit(VERSION.major == 1 && VERSION.minor == 12 ? 0 : 1)' >/dev/null 2>&1; then
+        "$juliaup_bin" add 1.12
+    fi
+    "$juliaup_bin" default 1.12
+    julia_bin="$HOME/.juliaup/bin/julia"
+
+    profile_marker="# NCTSSoS.jl Juliaup"
+    if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+        cat >> "$HOME/.bash_profile" <<'EOF'
+
+# NCTSSoS.jl Juliaup
+if [[ -d "$HOME/.juliaup/bin" ]]; then
+    export PATH="$HOME/.juliaup/bin:$PATH"
+fi
+EOF
+    fi
+fi
+"$julia_bin" --version
+
+# Mosek license via workspace secrets. Preferred: MOSEK_LICENSE_B64 (base64 of the
+# license file, e.g. `base64 -w0 mosek.lic`), which survives secret storage intact.
+# Fallback: MOSEK_LICENSE with raw contents; a value flattened to one line (literal
+# \n sequences instead of newlines) is repaired before writing.
+if [[ -n "${MOSEK_LICENSE_B64:-}" || -n "${MOSEK_LICENSE:-}" ]]; then
+    echo "==> Installing Mosek license at ~/mosek/mosek.lic"
+    install -d -m 700 "$HOME/mosek"
+    license_tmp="$(mktemp "$HOME/mosek/.mosek.lic.XXXXXX")"
+    trap 'rm -f -- "$license_tmp"' EXIT
+    if [[ -n "${MOSEK_LICENSE_B64:-}" ]]; then
+        printf '%s' "$MOSEK_LICENSE_B64" | base64 -d > "$license_tmp"
+    elif [[ "$MOSEK_LICENSE" == *$'\n'* ]]; then
+        printf '%s' "$MOSEK_LICENSE" | tr -d '\r' > "$license_tmp"
+    else
+        printf '%s' "$MOSEK_LICENSE" | sed 's/\\n/\n/g' | tr -d '\r' > "$license_tmp"
+    fi
+    chmod 600 "$license_tmp"
+    mv -f -- "$license_tmp" "$HOME/mosek/mosek.lic"
+    trap - EXIT
+fi
+
+echo "==> Instantiating and precompiling the package environment"
+SECONDS=0
+"$julia_bin" --project="$repo_root" -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'
+echo "==> Package environment ready in ${SECONDS}s"
+
+# The docs environment includes large optional dependencies (including CairoMakie and Yao),
+# so it is intentionally left on demand. Run `make init-docs` before docs work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,6 @@
 
 If `TASK.md` exists, read it after this file before starting work; detailed active-task context belongs under `plan/`.
 
-## Work Location
-- All repository work must be done through `easy-ssh`; use the configured remote workspace instead of running builds, tests, benchmarks, or implementation commands directly on the local checkout.
-
 ## Project Layout
 - `src/` — library code
   - `src/types/` — algebras, registries, monomials, polynomials
@@ -25,8 +22,7 @@ If `TASK.md` exists, read it after this file before starting work; detailed acti
 CI baseline: Julia 1.12; solver: COSMO.
 
 ### Run Policy
-- All computational runs (tests, benchmarks, examples, solver-backed scripts, and timing probes) must be launched through the `easy-ssh` skill; do not run them locally unless the user explicitly overrides this rule.
-- Prefer Mosek for ad hoc solver-backed runs when available; keep COSMO as the CI baseline unless the task is explicitly Mosek-only.
+- Prefer Mosek for ad hoc solver-backed runs when available; keep COSMO as the CI baseline unless the task is explicitly Mosek-only. Before relying on Mosek, check for `~/mosek/mosek.lic` or a configured Mosek licensing environment variable and verify the license with a trivial solve; importing `MosekTools` alone is not sufficient. Orb setup writes the contents of the `MOSEK_LICENSE` workspace secret to the standard license path.
 - Before launching any run, estimate the expected runtime and report it. After the run, report the actual elapsed time and whether it matched the estimate.
 
 - `make init` — precompile root environment
@@ -68,6 +64,7 @@ Optimization flow: `polyopt()` → `cs_nctssos()` → `compute_sparsity()` → m
   - `/Users/exaclior/notes/private-notes/test-expectations/test-examples.typ`
   - rendered companion: `/Users/exaclior/notes/private-notes/test-expectations/test-examples.pdf`
   - supporting paper summaries: `/Users/exaclior/notes/private-notes/test-expectations/references/md/`
+- These paths are available only on the maintainer's machine; agents without access should ask the user for the relevant backlog content.
 - When working from that backlog, process one requested example id at a time unless the user explicitly asks for batching.
 - Before adding a case, search existing coverage in `test/` and relevant docs examples under `docs/src/examples/literate/` to avoid duplicates. Prefer extending an existing nearby testset over creating a parallel near-copy.
 - If a candidate overlaps an existing test, strengthen the existing test with the missing assertion/input instead of adding repetitive coverage.


### PR DESCRIPTION
Prepares the repository for orb-based development.

- Add `.agents/setup`: installs Julia 1.12 via juliaup, instantiates + precompiles the root environment (cold ~2.5 min, warm ~2 s), and installs the Mosek license from workspace secrets (`MOSEK_LICENSE_B64` preferred, base64 of `mosek.lic`; tolerates stray pasted bytes and CR line endings; never logs the value; writes `~/mosek/mosek.lic` atomically with 700/600 modes).
- Add `.agents/resume`: no persistent services; fast no-op.
- AGENTS.md: remove the easy-ssh work-location mandate and remote run routing; add Mosek license preflight guidance; note that the backlog paths under `/Users/exaclior/...` exist only on the maintainer's machine.

## How to test

Verified in fresh orbs: cold setup exits 0 in ~91-163 s, warm rerun ~2 s; smoke test `julia --project=. test/polynomials/algebra_types.jl` passes (239 assertions); with `MOSEK_LICENSE_B64` set, a trivial 2x2 PSD SDP via JuMP+MosekTools returns OPTIMAL with objective 1.0.