### PR TITLE
perf: document exact k=10 TI Heisenberg acceptance run; add NCTS_MOSEK_TOL knob

### DIFF
--- a/perf/2604_01555_heisenberg_gap.md
+++ b/perf/2604_01555_heisenberg_gap.md
@@ -212,3 +212,38 @@ retained PSD state-optimality blocks: the smallest eigenvalue was
 `-2.04e-15`, and the largest linear-state-optimality residual was `3.86e-16`.
 This distinguishes the known Mosek numerical sensitivity from a symbolic
 sign or adjoint error in the new constraints.
+
+## 2026-08-14: exact paper configuration (k=10) on a large-memory host
+
+The exact QMBCertify configuration — `N=100`, 10-site RDM, `linear_psd` state
+optimality with separation-5 two-site words, and the axis-permutation
+quotient — was run on a 128-core, ~1 TiB host (`6xa800`) where the model fits.
+Settings: moment-LMI form, Mosek with 32 threads, `1e-8` feasibility and
+relative-gap tolerances, logging off.
+
+```text
+RESULT N=100 order=4 rdm=10 state=linear_psd state_range=5 axis_symmetry=true
+objective=-44.3291247035 per_site=-0.4432912470
+objective_bound=-44.3291243612 bound_per_site=-0.4432912436
+status=SLOW_PROGRESS primal=FEASIBLE_POINT dual=FEASIBLE_POINT
+wall=4693.3s max_block=252 n_blocks=214 unique_moments=31485
+```
+
+Peak RSS was 245.5 GiB (`Maximum resident set size: 257408656 kB`); wall time
+78.2 minutes.
+
+| configuration | bound / spin | vs paper `-0.4432378` | DMRG-relative gap |
+|:--|--:|--:|--:|
+| paper SDP New (k=10) | -0.4432378 | — | 0.0019% |
+| this k=10 run | -0.4432912436 | 5.34e-5 | 0.0139% |
+| practical k=9, range 10 | -0.4434115129 | 1.74e-4 | 0.0411% |
+| paper SDP Old | — | — | 0.0820% |
+
+The k=10 model tightens the bound by 3.2x over the practical k=9 model but
+still misses the `1e-5` parity target by about 5x.  Mosek terminated with
+`SLOW_PROGRESS` (both primal and dual statuses `FEASIBLE_POINT`, primal and
+dual objectives agreeing to `3.4e-7` absolute), so the remaining gap may be
+numerical stalling rather than model weakness.  A diagnostic rerun with 64
+threads, tolerances relaxed to `1e-7`, and Mosek logging enabled is used to
+distinguish the two; the harness exposes the tolerance through
+`NCTS_MOSEK_TOL` (default `1e-8`).

--- a/perf/ti_mosek_run.jl
+++ b/perf/ti_mosek_run.jl
@@ -15,6 +15,7 @@
 # in 23.4 s; N=100 bound=-44.4239941277 in 1640.5 s with ~270 GiB peak RSS.
 #
 # Env knobs: NCTS_MOSEK_THREADS (default cpu/4), NCTS_MOSEK_LOG (default 0),
+# NCTS_MOSEK_TOL (default 1e-8; primal/dual feasibility and relative gap),
 # NCTS_TI_DUALIZE (default false; set true to reproduce the dual SOS form),
 # NCTS_TI_NS (default 16,100), NCTS_TI_RDM (default 0), NCTS_TI_STATE
 # (default none), NCTS_TI_STATE_RANGE (default 5), and NCTS_TI_AXIS_SYMMETRY
@@ -37,13 +38,14 @@ using NCTSSoS: pauli_translation_invariant_nctssos, heisenberg_chain_hamiltonian
 
 function mosek_optimizer()
     threads = parse(Int, get(ENV, "NCTS_MOSEK_THREADS", string(max(1, div(Sys.CPU_THREADS, 4)))))
+    tol = parse(Float64, get(ENV, "NCTS_MOSEK_TOL", "1e-8"))
     return optimizer_with_attributes(
         Mosek.Optimizer,
         "MSK_IPAR_LOG" => parse(Int, get(ENV, "NCTS_MOSEK_LOG", "0")),
         "MSK_IPAR_NUM_THREADS" => threads,
-        "MSK_DPAR_INTPNT_CO_TOL_PFEAS" => 1e-8,
-        "MSK_DPAR_INTPNT_CO_TOL_DFEAS" => 1e-8,
-        "MSK_DPAR_INTPNT_CO_TOL_REL_GAP" => 1e-8,
+        "MSK_DPAR_INTPNT_CO_TOL_PFEAS" => tol,
+        "MSK_DPAR_INTPNT_CO_TOL_DFEAS" => tol,
+        "MSK_DPAR_INTPNT_CO_TOL_REL_GAP" => tol,
     )
 end
 
@@ -103,7 +105,7 @@ state_optimality = Symbol(get(ENV, "NCTS_TI_STATE", "none"))
 state_optimality_range = parse(Int, get(ENV, "NCTS_TI_STATE_RANGE", "5"))
 axis_permutation_symmetry = parse(Bool, get(ENV, "NCTS_TI_AXIS_SYMMETRY", "false"))
 println("host=$(gethostname()) julia=$(VERSION) started=$(Dates.now())")
-println("threads=$(get(ENV, "NCTS_MOSEK_THREADS", "auto(cpu/4)")) cpu_threads=$(Sys.CPU_THREADS) dualize=$dualize ns=$ns rdm=$rdm_level state=$state_optimality state_range=$state_optimality_range axis_symmetry=$axis_permutation_symmetry")
+println("threads=$(get(ENV, "NCTS_MOSEK_THREADS", "auto(cpu/4)")) cpu_threads=$(Sys.CPU_THREADS) tol=$(get(ENV, "NCTS_MOSEK_TOL", "1e-8")) dualize=$dualize ns=$ns rdm=$rdm_level state=$state_optimality state_range=$state_optimality_range axis_symmetry=$axis_permutation_symmetry")
 flush(stdout)
 
 for n in ns


### PR DESCRIPTION
## Summary

Documents the exact QMBCertify configuration (arXiv:2604.01555) for the N=100 TI Heisenberg chain — 10-site RDM, `linear_psd` state optimality with separation-5 words, axis-permutation quotient — run on a 128-core ~1 TiB host where the model fits (it OOMs in a 31 GiB orb).

- Certified bound/spin: **-0.4432912436**, vs paper target -0.4432378 (abs diff 5.34e-5) and prior practical k=9 result -0.4434115129 (1.74e-4). DMRG-relative gap improves from 0.0411% (k=9) to 0.0139%; paper SDP New achieves 0.0019%.
- Mosek stopped with `SLOW_PROGRESS` (primal/dual both `FEASIBLE_POINT`, objectives agreeing to 3.4e-7), 78.2 min wall, 245.5 GiB peak RSS, 32 threads, tol 1e-8.
- Adds `NCTS_MOSEK_TOL` env knob to `perf/ti_mosek_run.jl` (default 1e-8, unchanged behavior) and prints it in the startup line, supporting a diagnostic rerun at 1e-7 / 64 threads / logging on to distinguish numerical stalling from model weakness. That rerun is in progress; its outcome will be appended to this PR.

## How to test

- `julia --project -e 'Meta.parseall(read("perf/ti_mosek_run.jl", String))'` — parses.
- Perf-note-only + harness-knob change; no `src/` or `test/` changes, no examples stamp impact.
- Solver requirement: reproducing the documented run needs Mosek and ~250 GiB RAM.